### PR TITLE
Feature251

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/AttributeWithEmptyArgumentListCSharpTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/AttributeWithEmptyArgumentListCSharpTests.cs
@@ -7,7 +7,7 @@ using VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList;
 namespace VSDiagnostics.Test.Tests.Attributes
 {
     [TestClass]
-    public class AttributeWithEmptyArgumentListTests : CSharpCodeFixVerifier
+    public class AttributeWithEmptyArgumentListCSharpTests : CSharpCodeFixVerifier
     {
         protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AttributeWithEmptyArgumentListAnalyzer();
 
@@ -99,7 +99,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {   
-        [Flag()]
+        [Flags()]
         enum Foo
         {
             Bar, Baz
@@ -114,7 +114,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {   
-        [Flag]
+        [Flags]
         enum Foo
         {
             Bar, Baz
@@ -137,7 +137,7 @@ namespace ConsoleApplication1
 {
     class MyClass
     {   
-        [Flag]
+        [Flags]
         enum Foo
         {
             Bar, Baz

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/AttributeWithEmptyArgumentListVisualBasicTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/AttributeWithEmptyArgumentListVisualBasicTests.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynTester.Helpers.VisualBasic;
+using VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList;
+
+namespace VSDiagnostics.Test.Tests.Attributes
+{
+    [TestClass]
+    public class AttributeWithEmptyArgumentListTests : VisualBasicCodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AttributeWithEmptyArgumentListAnalyzer();
+
+        protected override CodeFixProvider CodeFixProvider => new AttributeWithEmptyArgumentListCodeFix();
+
+        [TestMethod]
+        public void AttributeWithEmptyArgumentList_AttributeWithEmptyArgumentList()
+        {
+            var original = @"
+Module Module1
+
+    <Obsolete()>
+    Sub Foo()
+
+    End Sub
+
+End Module";
+
+            var result = @"
+Module Module1
+
+    <Obsolete>
+    Sub Foo()
+
+    End Sub
+
+End Module";
+
+            VerifyDiagnostic(original, AttributeWithEmptyArgumentListAnalyzer.Rule.MessageFormat.ToString());
+            VerifyFix(original, result);
+        }
+
+        [TestMethod]
+        public void AttributeWithEmptyArgumentList_WithoutArgumentList()
+        {
+            var original = @"
+Module Module1
+
+    <Obsolete>
+    Sub Foo()
+
+    End Sub
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void AttributeWithEmptyArgumentList_WithArgumentList()
+        {
+            var original = @"
+Module Module1
+
+    <Obsolete(""test"", true)>
+    Sub Foo()
+
+    End Sub
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+
+        // make sure it works on other attributes besides [Obsolete]
+        [TestMethod]
+        public void AttributeWithEmptyArgumentList_AttributeWithEmptyArgumentList_FlagsAttribute()
+        {
+            var original = @"
+Module Module1
+    
+    <Flags()>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            var result = @"
+Module Module1
+    
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original, AttributeWithEmptyArgumentListAnalyzer.Rule.MessageFormat.ToString());
+            VerifyFix(original, result);
+        }
+
+        // make sure it works on other attributes besides [Obsolete]
+        [TestMethod]
+        public void AttributeWithEmptyArgumentList_WithoutArgumentList_FlagsAttribute()
+        {
+            var original = @"
+Module Module1
+    
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeCSharpTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeCSharpTests.cs
@@ -7,7 +7,7 @@ using VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute;
 namespace VSDiagnostics.Test.Tests.Attributes
 {
     [TestClass]
-    public class EnumCanHaveFlagsAttributeTests : CSharpCodeFixVerifier
+    public class EnumCanHaveFlagsAttributeCSharpTests : CSharpCodeFixVerifier
     {
         protected override DiagnosticAnalyzer DiagnosticAnalyzer => new EnumCanHaveFlagsAttributeAnalyzer();
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeCSharpTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeCSharpTests.cs
@@ -163,8 +163,8 @@ namespace ConsoleApplication1
 }";
 
             var result =
-@"using System;
-using System.Text;
+@"using System.Text;
+using System;
 
 namespace ConsoleApplication1
 {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeVisualBasicTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeVisualBasicTests.cs
@@ -1,0 +1,159 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynTester.Helpers.VisualBasic;
+using VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute;
+
+namespace VSDiagnostics.Test.Tests.Attributes
+{
+    [TestClass]
+    public class EnumCanHaveFlagsAttributeVisualBasicTests : VisualBasicCodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer DiagnosticAnalyzer => new EnumCanHaveFlagsAttributeAnalyzer();
+
+        protected override CodeFixProvider CodeFixProvider => new EnumCanHaveFlagsAttributeCodeFix();
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_AddsFlagsAttribute()
+        {
+            var original = @"
+Module Module1
+
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            var result = @"
+Module Module1
+
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original, EnumCanHaveFlagsAttributeAnalyzer.Rule.MessageFormat.ToString());
+            VerifyFix(original, result);
+        }
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_AddsFlagsAttribute_OnlyAddsFlagsAttribute()
+        {
+            var original = @"
+Module Module1
+
+    <Obsolete(""I'm obsolete"")>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            var result = @"
+Module Module1
+
+    <Obsolete(""I'm obsolete"")>
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original, EnumCanHaveFlagsAttributeAnalyzer.Rule.MessageFormat.ToString());
+            VerifyFix(original, result);
+        }
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_EnumHasXmlDocComment_OnlyAddsFlagsAttribute()
+        {
+            var original = @"
+Module Module1
+
+    ''' <summary>
+    ''' Doc comment for Foo...
+    ''' </summary>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            var result = @"
+Module Module1
+
+    ''' <summary>
+    ''' Doc comment for Foo...
+    ''' </summary>
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original, EnumCanHaveFlagsAttributeAnalyzer.Rule.MessageFormat.ToString());
+            VerifyFix(original, result);
+        }
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAlreadyApplied()
+        {
+            var original = @"
+Module Module1
+
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAttributeAlreadyApplied()
+        {
+            var original = @"
+Module Module1
+
+    <FlagsAttribute>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAlreadyAppliedAsChain()
+        {
+            var original = @"
+Module Module1
+
+    <Obsolete(""I'm obsolete""), Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
+
+            VerifyDiagnostic(original);
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeVisualBasicTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/EnumCanHaveFlagsAttributeVisualBasicTests.cs
@@ -27,8 +27,8 @@ Module Module1
 End Module";
 
             var result = @"
-Module Module1
-
+Imports System
+Module Module
     <Flags>
     Enum Foo
         Bar
@@ -45,6 +45,7 @@ End Module";
         public void EnumCanHaveFlagsAttribute_AddsFlagsAttribute_OnlyAddsFlagsAttribute()
         {
             var original = @"
+Imports System
 Module Module1
 
     <Obsolete(""I'm obsolete"")>
@@ -56,6 +57,7 @@ Module Module1
 End Module";
 
             var result = @"
+Imports System
 Module Module1
 
     <Obsolete(""I'm obsolete"")>
@@ -88,6 +90,7 @@ Module Module1
 End Module";
 
             var result = @"
+Imports System
 Module Module1
 
     ''' <summary>
@@ -109,6 +112,7 @@ End Module";
         public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAlreadyApplied()
         {
             var original = @"
+Imports System
 Module Module1
 
     <Flags>
@@ -126,6 +130,7 @@ End Module";
         public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAttributeAlreadyApplied()
         {
             var original = @"
+Imports System
 Module Module1
 
     <FlagsAttribute>
@@ -143,6 +148,7 @@ End Module";
         public void EnumCanHaveFlagsAttribute_InspectionDoesNotReturnWhenFlagsAlreadyAppliedAsChain()
         {
             var original = @"
+Imports System
 Module Module1
 
     <Obsolete(""I'm obsolete""), Flags>

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonCSharpTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonCSharpTests.cs
@@ -1,0 +1,193 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynTester.Helpers.CSharp;
+using VSDiagnostics.Diagnostics.Attributes.ObsoleteAttributeWithoutReason;
+
+namespace VSDiagnostics.Test.Tests.Attributes
+{
+    [TestClass]
+    public class ObsoleteAttributeWithoutReasonCSharpTests : CSharpDiagnosticVerifier
+    {
+        protected override DiagnosticAnalyzer DiagnosticAnalyzer => new ObsoleteAttributeWithoutReasonAnalyzer();
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteWithNullArgumentList()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [Obsolete]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithoutReason()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [ObsoleteAttribute]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteWithEmptyArgumentList()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [Obsolete()]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithEmptyArgumentList()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [ObsoleteAttribute()]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteWithArgument()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [Obsolete(""I have an argument."")]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArgument()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [ObsoleteAttribute(""I have an argument."")]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteWithArguments()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [Obsolete(""I have two arguments."", true)]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArguments()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [ObsoleteAttribute(""I have two arguments."", true)]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void ObsoleteAttributeWithoutReason_NonObsoleteAttribute()
+        {
+            var test = @"
+using System;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        [MTAThread]
+        void Method(string input)
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(test);
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonVisualBasicTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonVisualBasicTests.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using RoslynTester.Helpers.CSharp;
+using RoslynTester.Helpers.VisualBasic;
 using VSDiagnostics.Diagnostics.Attributes.ObsoleteAttributeWithoutReason;
 
 namespace VSDiagnostics.Test.Tests.Attributes
 {
     [TestClass]
-    public class ObsoleteAttributeWithoutReasonTests : CSharpDiagnosticVerifier
+    public class ObsoleteAttributeWithoutReasonVisualBasicTests : VisualBasicDiagnosticVerifier
     {
         protected override DiagnosticAnalyzer DiagnosticAnalyzer => new ObsoleteAttributeWithoutReasonAnalyzer();
 
@@ -14,18 +14,15 @@ namespace VSDiagnostics.Test.Tests.Attributes
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithNullArgumentList()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [Obsolete]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <Obsolete>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
         }
@@ -34,18 +31,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithoutReason()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [ObsoleteAttribute]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <ObsoleteAttribute>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
         }
@@ -54,18 +48,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithEmptyArgumentList()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [Obsolete()]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <Obsolete()>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
         }
@@ -74,18 +65,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithEmptyArgumentList()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [ObsoleteAttribute()]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <ObsoleteAttribute()>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test, ObsoleteAttributeWithoutReasonAnalyzer.Rule.MessageFormat.ToString());
         }
@@ -94,18 +82,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithArgument()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [Obsolete(""I have an argument."")]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <Obsolete(""I have an argument."")>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test);
         }
@@ -114,18 +99,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArgument()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [ObsoleteAttribute(""I have an argument."")]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <ObsoleteAttribute(""I have an argument."")>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test);
         }
@@ -134,18 +116,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithArguments()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [Obsolete(""I have two arguments."", true)]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <Obsolete(""I have two arguments."", true)>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test);
         }
@@ -154,18 +133,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArguments()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [ObsoleteAttribute(""I have two arguments."", true)]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <ObsoleteAttribute(""I have two arguments."", true)>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test);
         }
@@ -174,18 +150,15 @@ namespace ConsoleApplication1
         public void ObsoleteAttributeWithoutReason_NonObsoleteAttribute()
         {
             var test = @"
-using System;
+Module Module1
 
-namespace ConsoleApplication1
-{
-    class MyClass
-    {   
-        [MTAThread]
-        void Method(string input)
-        {
-        }
-    }
-}";
+    <Flags>
+    Enum Foo
+        Bar
+        Baz
+    End Enum
+
+End Module";
 
             VerifyDiagnostic(test);
         }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonVisualBasicTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Attributes/ObsoleteAttributeWithoutReasonVisualBasicTests.cs
@@ -14,6 +14,7 @@ namespace VSDiagnostics.Test.Tests.Attributes
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithNullArgumentList()
         {
             var test = @"
+Imports System
 Module Module1
 
     <Obsolete>
@@ -31,6 +32,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithoutReason()
         {
             var test = @"
+Imports System
 Module Module1
 
     <ObsoleteAttribute>
@@ -48,6 +50,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithEmptyArgumentList()
         {
             var test = @"
+Imports System
 Module Module1
 
     <Obsolete()>
@@ -65,6 +68,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithEmptyArgumentList()
         {
             var test = @"
+Imports System
 Module Module1
 
     <ObsoleteAttribute()>
@@ -82,6 +86,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithArgument()
         {
             var test = @"
+Imports System
 Module Module1
 
     <Obsolete(""I have an argument."")>
@@ -99,6 +104,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArgument()
         {
             var test = @"
+Imports System
 Module Module1
 
     <ObsoleteAttribute(""I have an argument."")>
@@ -116,6 +122,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteWithArguments()
         {
             var test = @"
+Imports System
 Module Module1
 
     <Obsolete(""I have two arguments."", true)>
@@ -133,6 +140,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_WithObsoleteAttributeWithArguments()
         {
             var test = @"
+Imports System
 Module Module1
 
     <ObsoleteAttribute(""I have two arguments."", true)>
@@ -150,6 +158,7 @@ End Module";
         public void ObsoleteAttributeWithoutReason_NonObsoleteAttribute()
         {
             var test = @"
+Imports System
 Module Module1
 
     <Flags>

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
@@ -66,8 +66,8 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RoslynTester, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RoslynTester.1.4.0\lib\RoslynTester.dll</HintPath>
+    <Reference Include="RoslynTester, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RoslynTester.1.5.0\lib\RoslynTester.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -112,7 +112,8 @@
     <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListCSharpTests.cs" />
     <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeVisualBasicTests.cs" />
     <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeCSharpTests.cs" />
-    <Compile Include="Tests\Attributes\ObsoleteAttributeWithoutReasonTests.cs" />
+    <Compile Include="Tests\Attributes\ObsoleteAttributeWithoutReasonVisualBasicTests.cs" />
+    <Compile Include="Tests\Attributes\ObsoleteAttributeWithoutReasonCSharpTests.cs" />
     <Compile Include="Tests\Attributes\OnPropertyChangedWithoutCallerMemberNameTests.cs" />
     <Compile Include="Tests\Exceptions\ArgumentExceptionWithoutNameofOperatorTests.cs" />
     <Compile Include="Tests\Exceptions\CatchNullReferenceExceptionTests.cs" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
@@ -110,7 +110,8 @@
     <Compile Include="Tests\Async\AsyncMethodWithoutAsyncSuffixTests.cs" />
     <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListVisualBasicTests.cs" />
     <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListCSharpTests.cs" />
-    <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeTests.cs" />
+    <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeVisualBasicTests.cs" />
+    <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeCSharpTests.cs" />
     <Compile Include="Tests\Attributes\ObsoleteAttributeWithoutReasonTests.cs" />
     <Compile Include="Tests\Attributes\OnPropertyChangedWithoutCallerMemberNameTests.cs" />
     <Compile Include="Tests\Exceptions\ArgumentExceptionWithoutNameofOperatorTests.cs" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
@@ -108,7 +108,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tests\Async\AsyncMethodWithoutAsyncSuffixTests.cs" />
-    <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListTests.cs" />
+    <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListVisualBasicTests.cs" />
+    <Compile Include="Tests\Attributes\AttributeWithEmptyArgumentListCSharpTests.cs" />
     <Compile Include="Tests\Attributes\EnumCanHaveFlagsAttributeTests.cs" />
     <Compile Include="Tests\Attributes\ObsoleteAttributeWithoutReasonTests.cs" />
     <Compile Include="Tests\Attributes\OnPropertyChangedWithoutCallerMemberNameTests.cs" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Vsix/VSDiagnostics.Vsix.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Vsix/VSDiagnostics.Vsix.csproj
@@ -47,6 +47,7 @@
     <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -56,6 +57,73 @@
       <Project>{C7BF0415-8F01-4FF1-8EC3-71695197EF5B}</Project>
       <Name>VSDiagnostics</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="RoslynTester, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RoslynTester.1.5.0\lib\RoslynTester.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Vsix/packages.config
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Vsix/packages.config
@@ -8,8 +8,7 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="RoslynTester" version="1.5.0" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/AttributeWithEmptyArgumentList/AttributeWithEmptyArgumentListAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/AttributeWithEmptyArgumentList/AttributeWithEmptyArgumentListAnalyzer.cs
@@ -1,6 +1,10 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using CSharpSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+using VisualBasicSyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
+using CSharpAttributeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax;
+using VisualBasicAttributeSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax;
 
 namespace VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList
 {
@@ -20,13 +24,13 @@ namespace VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(AnalyzeCSharpSymbol, Microsoft.CodeAnalysis.CSharp.SyntaxKind.Attribute);
-            context.RegisterSyntaxNodeAction(AnalyzeVisualBasicSymbol, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnalyzeCSharpSymbol, CSharpSyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnalyzeVisualBasicSymbol, VisualBasicSyntaxKind.Attribute);
         }
 
         private void AnalyzeCSharpSymbol(SyntaxNodeAnalysisContext context)
         {
-            var attributeExpression = context.Node as Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax;
+            var attributeExpression = context.Node as CSharpAttributeSyntax;
             
             // attribute must have arguments
             // if there are no parenthesis, the ArgumentList is null
@@ -41,7 +45,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList
 
         private void AnalyzeVisualBasicSymbol(SyntaxNodeAnalysisContext context)
         {
-            var attributeExpression = context.Node as Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax;
+            var attributeExpression = context.Node as VisualBasicAttributeSyntax;
 
             // attribute must have arguments
             // if there are no parenthesis, the ArgumentList is null

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/AttributeWithEmptyArgumentList/AttributeWithEmptyArgumentListCodeFix.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/AttributeWithEmptyArgumentList/AttributeWithEmptyArgumentListCodeFix.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using CSharpAttributeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax;
+using VisualBasicAttributeSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax;
 
 namespace VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList
 {
@@ -29,25 +31,25 @@ namespace VSDiagnostics.Diagnostics.Attributes.AttributeWithEmptyArgumentList
         {
             SyntaxNode newRoot = null;
 
-            if (statement is Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax)
+            if (statement is CSharpAttributeSyntax)
             {
-                newRoot = RemoveEmptyArgumentListCSharp(root, (Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax)statement);
+                newRoot = RemoveEmptyArgumentListCSharp(root, (CSharpAttributeSyntax)statement);
             }
-            else if (statement is Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax)
+            else if (statement is VisualBasicAttributeSyntax)
             {
-                newRoot = RemoveEmptyArgumentListVisualBasic(root, (Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax)statement);
+                newRoot = RemoveEmptyArgumentListVisualBasic(root, (VisualBasicAttributeSyntax)statement);
             }
 
             var newDocument = document.WithSyntaxRoot(newRoot);
             return Task.FromResult(newDocument.Project.Solution);
         }
 
-        private SyntaxNode RemoveEmptyArgumentListCSharp(SyntaxNode root, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax attributeExpression)
+        private SyntaxNode RemoveEmptyArgumentListCSharp(SyntaxNode root, CSharpAttributeSyntax attributeExpression)
         {
             return root.RemoveNode(attributeExpression.ArgumentList, SyntaxRemoveOptions.KeepNoTrivia);
         }
 
-        private SyntaxNode RemoveEmptyArgumentListVisualBasic(SyntaxNode root, Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax attributeExpression)
+        private SyntaxNode RemoveEmptyArgumentListVisualBasic(SyntaxNode root, VisualBasicAttributeSyntax attributeExpression)
         {
             return root.RemoveNode(attributeExpression.ArgumentList, SyntaxRemoveOptions.KeepNoTrivia);
         }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeCodeFix.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeCodeFix.cs
@@ -86,7 +86,11 @@ namespace VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute
             var compilationUnit = (VisualBasicCompilationUnitSyntax)newRoot;
 
             var importSystemClause =
-                VisualBasicSyntaxFactory.SimpleImportsClause(VisualBasicSyntaxFactory.ParseName("System" + Environment.NewLine));
+                VisualBasicSyntaxFactory.SimpleImportsClause(
+                    VisualBasicSyntaxFactory.ParseName("System"))
+                    .WithTrailingTrivia(
+                        VisualBasicSyntaxFactory.SyntaxTrivia(
+                            Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.EndOfLineTrivia, Environment.NewLine));
             var importsList = VisualBasicSyntaxFactory.SeparatedList(new List<ImportsClauseSyntax> { importSystemClause });
             var importStatement = VisualBasicSyntaxFactory.ImportsStatement(importsList);
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/ObsoleteAttributeWithoutReason/ObsoleteAttributeWithoutReasonAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/ObsoleteAttributeWithoutReason/ObsoleteAttributeWithoutReasonAnalyzer.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using CSharpSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+using VisualBasicSyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
+using CSharpAttributeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax;
+using VisualBasicAttributeSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax;
 
 namespace VSDiagnostics.Diagnostics.Attributes.ObsoleteAttributeWithoutReason
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class ObsoleteAttributeWithoutReasonAnalyzer : DiagnosticAnalyzer
     {
         private const string DiagnosticId = nameof(ObsoleteAttributeWithoutReasonAnalyzer);
@@ -23,12 +25,13 @@ namespace VSDiagnostics.Diagnostics.Attributes.ObsoleteAttributeWithoutReason
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(AnalyzeSymbol, SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnalyzeCSharpSymbol, CSharpSyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnalyzeVisualBasicSymbol, VisualBasicSyntaxKind.Attribute);
         }
 
-        private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
+        private void AnalyzeCSharpSymbol(SyntaxNodeAnalysisContext context)
         {
-            var attributeExpression = context.Node as AttributeSyntax;
+            var attributeExpression = context.Node as CSharpAttributeSyntax;
             if (attributeExpression == null)
             {
                 return;
@@ -37,6 +40,32 @@ namespace VSDiagnostics.Diagnostics.Attributes.ObsoleteAttributeWithoutReason
             // attribute type must be of type ObsoleteAttribute
             var type = context.SemanticModel.GetSymbolInfo(attributeExpression).Symbol;
             if (type == null || type.ContainingType.MetadataName != typeof (ObsoleteAttribute).Name)
+            {
+                return;
+            }
+
+            // attribute must have arguments
+            // if there are no parenthesis, the ArgumentList is null
+            // if there are empty parenthesis, the ArgumentList is empty
+            if (attributeExpression.ArgumentList != null && attributeExpression.ArgumentList.Arguments.Any())
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, attributeExpression.GetLocation()));
+        }
+
+        private void AnalyzeVisualBasicSymbol(SyntaxNodeAnalysisContext context)
+        {
+            var attributeExpression = context.Node as VisualBasicAttributeSyntax;
+            if (attributeExpression == null)
+            {
+                return;
+            }
+
+            // attribute type must be of type ObsoleteAttribute
+            var type = context.SemanticModel.GetSymbolInfo(attributeExpression).Symbol;
+            if (type == null || type.ContainingType.MetadataName != typeof(ObsoleteAttribute).Name)
             {
                 return;
             }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnostics.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnostics.csproj
@@ -145,6 +145,10 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="RoslynTester, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RoslynTester.1.5.0\lib\RoslynTester.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.Designer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.Designer.cs
@@ -431,7 +431,7 @@ namespace VSDiagnostics {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enum can have [Flags] attribute..
+        ///   Looks up a localized string similar to Enum can have Flags attribute..
         /// </summary>
         internal static string EnumCanHaveFlagsAttributeAnalyzerMessage {
             get {
@@ -440,7 +440,7 @@ namespace VSDiagnostics {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inform that enums can have the [Flags] attribute..
+        ///   Looks up a localized string similar to Inform that enums can have the Flags attribute..
         /// </summary>
         internal static string EnumCanHaveFlagsAttributeAnalyzerTitle {
             get {
@@ -449,7 +449,7 @@ namespace VSDiagnostics {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add [Flags] attribute.
+        ///   Looks up a localized string similar to Add Flags attribute.
         /// </summary>
         internal static string EnumCanHaveFlagsAttributeCodeFixTitle {
             get {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.resx
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.resx
@@ -412,13 +412,13 @@
     <value>Use powers of 2</value>
   </data>
   <data name="EnumCanHaveFlagsAttributeAnalyzerMessage" xml:space="preserve">
-    <value>Enum can have [Flags] attribute.</value>
+    <value>Enum can have Flags attribute.</value>
   </data>
   <data name="EnumCanHaveFlagsAttributeAnalyzerTitle" xml:space="preserve">
-    <value>Inform that enums can have the [Flags] attribute.</value>
+    <value>Inform that enums can have the Flags attribute.</value>
   </data>
   <data name="EnumCanHaveFlagsAttributeCodeFixTitle" xml:space="preserve">
-    <value>Add [Flags] attribute</value>
+    <value>Add Flags attribute</value>
   </data>
   <data name="ConditionIsAlwaysTrueAnalyzerMessage" xml:space="preserve">
     <value>Condition is always true.</value>

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/packages.config
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
@@ -9,6 +8,7 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="NuGet.CommandLine" version="2.8.2" targetFramework="portable45-net45+win8" />
+  <package id="RoslynTester" version="1.5.0" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="portable45-net45+win8" />
 </packages>


### PR DESCRIPTION
Reference #251 
Analyze and fix attribute with empty argument list.

Certain unit tests fail because the current release of RoslynTester has a bug.  I have fixed the bug and it has been merged, so we can merge this after the the updated version is released and included here.