### PR TITLE
Extract async checking to extension method

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using RoslynTester.DiagnosticResults;
 using RoslynTester.Helpers.CSharp;
 using VSDiagnostics.Diagnostics.Async.AsyncMethodWithoutAsyncSuffix;
 
@@ -15,84 +14,7 @@ namespace VSDiagnostics.Test.Tests.Async
         protected override DiagnosticAnalyzer DiagnosticAnalyzer => new AsyncMethodWithoutAsyncSuffixAnalyzer();
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithAsyncKeywordAndNoSuffix()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            async Task Method()
-            {
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            async Task MethodAsync()
-            {
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "Method"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithAsyncKeywordAndSuffix()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            async Task MethodAsync()
-            {
-            }
-        }
-    }";
-            VerifyDiagnostic(original);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithoutAsyncKeywordAndSuffix()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            void Method()
-            {
-            }
-        }
-    }";
-            VerifyDiagnostic(original);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithTaskReturnType()
+        public void AsyncMethodWithoutAsyncSuffix_WithAsyncMethodAndNoSuffix()
         {
             var original = @"
     using System;
@@ -130,9 +52,49 @@ namespace VSDiagnostics.Test.Tests.Async
             VerifyFix(original, result);
         }
 
+        [TestMethod]
+        public void AsyncMethodWithoutAsyncSuffix_WithAsyncMethodAndSuffix()
+        {
+            var original = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {   
+            Task MethodAsync()
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }";
+            VerifyDiagnostic(original);
+        }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithTaskReturnType()
+        public void AsyncMethodWithoutAsyncSuffix_WithSynchronousMethodAndNoSuffix()
+        {
+            var original = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {   
+            void Method()
+            {
+            }
+        }
+    }";
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface()
         {
             var original = @"
     using System;
@@ -214,102 +176,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithImplementedMember_AndAsyncModifier()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        interface IMyInterface
-        {
-            Task MyMethod();
-        }
-
-        class MyClass : IMyInterface
-        {
-            public async Task MyMethod()
-            {
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        interface IMyInterface
-        {
-            Task MyMethodAsync();
-        }
-
-        class MyClass : IMyInterface
-        {
-            public async Task MyMethodAsync()
-            {
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithAsyncModifier()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        abstract class BaseClass
-        {
-            public abstract Task MyMethod();
-        }
-
-        class MyClass : BaseClass
-        {
-            public override async Task MyMethod()
-            {
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        abstract class BaseClass
-        {
-            public abstract Task MyMethodAsync();
-        }
-
-        class MyClass : BaseClass
-        {
-            public override async Task MyMethodAsync()
-            {
-            }
-        }
-    }";
-
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithTaskReturnType()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod()
         {
             var original = @"
     using System;
@@ -358,60 +225,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithAsyncModifier()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class BaseClass
-        {
-            public virtual Task MyMethod()
-            {
-                return Task.FromResult(5);
-            }
-        }
-
-        class MyClass : BaseClass
-        {
-            public override async Task MyMethod()
-            {
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class BaseClass
-        {
-            public virtual Task MyMethodAsync()
-            {
-                return Task.FromResult(5);
-            }
-        }
-
-        class MyClass : BaseClass
-        {
-            public override async Task MyMethodAsync()
-            {
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithTaskReturnType()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod()
         {
             var original = @"
     using System;
@@ -726,45 +540,6 @@ namespace VSDiagnostics.Test.Tests.Async
                 original,
                 string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"),
                 string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithVoidReturnType()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            async void Method()
-            {
-
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            async void MethodAsync()
-            {
-
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "Method"));
             VerifyFix(original, result);
         }
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
@@ -52,7 +52,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithAsyncKeywordAndSuffix_DoesNotDisplayWarning()
+        public void AsyncMethodWithoutAsyncSuffix_WithAsyncKeywordAndSuffix()
         {
             var original = @"
     using System;
@@ -72,7 +72,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithoutAsyncKeywordAndSuffix_DoesNotDisplayWarning()
+        public void AsyncMethodWithoutAsyncSuffix_WithoutAsyncKeywordAndSuffix()
         {
             var original = @"
     using System;
@@ -92,7 +92,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_WithTaskReturnType()
         {
             var original = @"
     using System;
@@ -131,7 +131,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithGenericTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_WithGenericTaskReturnType()
         {
             var original = @"
     using System;
@@ -170,7 +170,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithTaskReturnType()
         {
             var original = @"
     using System;
@@ -203,7 +203,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithGenericTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithGenericTaskReturnType()
         {
             var original = @"
     using System;
@@ -236,7 +236,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithImplementedMember_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithImplementedMember()
         {
             var original = @"
     using System;
@@ -285,7 +285,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithImplementedMember_AndAsyncModifier_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithImplementedMember_AndAsyncModifier()
         {
             var original = @"
     using System;
@@ -332,7 +332,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithAsyncModifier_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithAsyncModifier()
         {
             var original = @"
     using System;
@@ -380,7 +380,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithTaskReturnType()
         {
             var original = @"
     using System;
@@ -429,7 +429,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithGenricTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithGenricTaskReturnType()
         {
             var original = @"
     using System;
@@ -478,7 +478,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithAsyncModifier_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithAsyncModifier()
         {
             var original = @"
     using System;
@@ -531,7 +531,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithTaskReturnType()
         {
             var original = @"
     using System;
@@ -586,7 +586,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithGenericTaskReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithGenericTaskReturnType()
         {
             var original = @"
     using System;
@@ -641,7 +641,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithClasses_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithClasses()
         {
             var original = @"
     using System;
@@ -712,7 +712,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithLongerInheritanceStructure_WithInterfaces_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithLongerInheritanceStructure_WithInterfaces()
         {
             var original = @"
     using System;
@@ -771,7 +771,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithInterfacesAndClasses_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithInterfacesAndClasses()
         {
             var original = @"
     using System;
@@ -843,7 +843,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithMultipleInterfaces_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithMultipleInterfaces()
         {
             var original = @"
     using System;
@@ -905,7 +905,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithVoidReturnType_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_WithVoidReturnType()
         {
             var original = @"
     using System;
@@ -944,7 +944,7 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithMultipleAbstractClasses_InvokesWarning()
+        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_WithLongerInheritanceStructure_WithMultipleAbstractClasses()
         {
             var original = @"
     using System;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Async/AsyncMethodWithoutAsyncSuffixTests.cs
@@ -130,44 +130,6 @@ namespace VSDiagnostics.Test.Tests.Async
             VerifyFix(original, result);
         }
 
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_WithGenericTaskReturnType()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            Task<int> Method()
-            {
-                return Task.FromResult(5);
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class MyClass
-        {   
-            Task<int> MethodAsync()
-            {
-                return Task.FromResult(5);
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "Method"));
-            VerifyFix(original, result);
-        }
 
         [TestMethod]
         public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithTaskReturnType()
@@ -195,39 +157,6 @@ namespace VSDiagnostics.Test.Tests.Async
         interface IMyInterface
         {
             Task MyMethodAsync();
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInInterface_WithGenericTaskReturnType()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        interface IMyInterface
-        {
-            Task<int> MyMethod();
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        interface IMyInterface
-        {
-            Task<int> MyMethodAsync();
         }
     }";
 
@@ -429,55 +358,6 @@ namespace VSDiagnostics.Test.Tests.Async
         }
 
         [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromAbstractMethod_WithGenricTaskReturnType()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        abstract class BaseClass
-        {
-            public abstract Task<int> MyMethod();
-        }
-
-        class MyClass : BaseClass
-        {
-            public override Task<int> MyMethod()
-            {
-                return Task.FromResult(5);
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        abstract class BaseClass
-        {
-            public abstract Task<int> MyMethodAsync();
-        }
-
-        class MyClass : BaseClass
-        {
-            public override Task<int> MyMethodAsync()
-            {
-                return Task.FromResult(5);
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
         public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithAsyncModifier()
         {
             var original = @"
@@ -577,61 +457,6 @@ namespace VSDiagnostics.Test.Tests.Async
             public override Task MyMethodAsync()
             {
                 return Task.FromResult(5);
-            }
-        }
-    }";
-
-            VerifyDiagnostic(original, string.Format(AsyncMethodWithoutAsyncSuffixAnalyzer.Rule.MessageFormat.ToString(), "MyMethod"));
-            VerifyFix(original, result);
-        }
-
-        [TestMethod]
-        public void AsyncMethodWithoutAsyncSuffix_DefinedInBaseClass_WithOverriddenMember_FromVirtualMethod_WithGenericTaskReturnType()
-        {
-            var original = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class BaseClass
-        {
-            public virtual Task<int> MyMethod()
-            {
-                return Task.FromResult(5);
-            }
-        }
-
-        class MyClass : BaseClass
-        {
-            public override Task<int> MyMethod()
-            {
-                return Task.FromResult(8);
-            }
-        }
-    }";
-
-            var result = @"
-    using System;
-    using System.Text;
-    using System.Threading.Tasks;
-
-    namespace ConsoleApplication1
-    {
-        class BaseClass
-        {
-            public virtual Task<int> MyMethodAsync()
-            {
-                return Task.FromResult(5);
-            }
-        }
-
-        class MyClass : BaseClass
-        {
-            public override Task<int> MyMethodAsync()
-            {
-                return Task.FromResult(8);
             }
         }
     }";

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Utilities/ExtensionsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Utilities/ExtensionsTests.cs
@@ -118,15 +118,7 @@ namespace VSDiagnostics.Test.Tests.Utilities
         }
     }";
 
-            var tree = CSharpSyntaxTree.ParseText(source);
-            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
-            var semanticModel = compilation.GetSemanticModel(tree);
-
-            var root = tree.GetRoot();
-            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
-            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            Assert.IsTrue(methodSymbol.IsAsync());
+            AssertMethodIsAsync(source, expectedAsync: true);
         }
 
         [TestMethod]
@@ -147,15 +139,7 @@ namespace VSDiagnostics.Test.Tests.Utilities
             }
     }";
 
-            var tree = CSharpSyntaxTree.ParseText(source);
-            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
-            var semanticModel = compilation.GetSemanticModel(tree);
-
-            var root = tree.GetRoot();
-            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
-            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            Assert.IsTrue(methodSymbol.IsAsync());
+            AssertMethodIsAsync(source, expectedAsync: true);
         }
 
         [TestMethod]
@@ -176,15 +160,7 @@ namespace VSDiagnostics.Test.Tests.Utilities
             }
     }";
 
-            var tree = CSharpSyntaxTree.ParseText(source);
-            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
-            var semanticModel = compilation.GetSemanticModel(tree);
-
-            var root = tree.GetRoot();
-            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
-            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            Assert.IsTrue(methodSymbol.IsAsync());
+            AssertMethodIsAsync(source, expectedAsync: true);
         }
 
         [TestMethod]
@@ -204,15 +180,7 @@ namespace VSDiagnostics.Test.Tests.Utilities
             }
     }";
 
-            var tree = CSharpSyntaxTree.ParseText(source);
-            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
-            var semanticModel = compilation.GetSemanticModel(tree);
-
-            var root = tree.GetRoot();
-            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
-            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            Assert.IsTrue(methodSymbol.IsAsync());
+            AssertMethodIsAsync(source, expectedAsync: true);
         }
 
         [TestMethod]
@@ -232,6 +200,11 @@ namespace VSDiagnostics.Test.Tests.Utilities
             }
     }";
 
+            AssertMethodIsAsync(source, expectedAsync: false);
+        }
+
+        private static void AssertMethodIsAsync(string source, bool expectedAsync)
+        {
             var tree = CSharpSyntaxTree.ParseText(source);
             var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
             var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
@@ -240,7 +213,7 @@ namespace VSDiagnostics.Test.Tests.Utilities
             var root = tree.GetRoot();
             var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
             var methodSymbol = semanticModel.GetDeclaredSymbol(method);
-            Assert.IsFalse(methodSymbol.IsAsync());
+            Assert.AreEqual(expectedAsync, methodSymbol.IsAsync());
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Utilities/ExtensionsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Utilities/ExtensionsTests.cs
@@ -99,5 +99,148 @@ namespace VSDiagnostics.Test.Tests.Utilities
             var typeSymbol = semanticModel.GetSymbolInfo(objectCreationExpression.Type);
             Assert.IsTrue(typeSymbol.Symbol.InheritsFrom(typeof(Exception)));
         }
+
+        [TestMethod]
+        public void IsAsync_WithAsyncKeywordAndTaskReturnType()
+        {
+            var source = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {
+            async Task Method()
+            {
+            }
+        }
+    }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            Assert.IsTrue(methodSymbol.IsAsync());
+        }
+
+        [TestMethod]
+        public void IsAsync_WithTaskReturnType()
+        {
+            var source = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {
+            Task Method()
+            {
+                return Task.CompletedTask;
+            }
+    }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            Assert.IsTrue(methodSymbol.IsAsync());
+        }
+
+        [TestMethod]
+        public void IsAsync_WithGenericTaskReturnType()
+        {
+            var source = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {
+            Task<int> Method()
+            {
+                return Task.FromResult(0);
+            }
+    }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            Assert.IsTrue(methodSymbol.IsAsync());
+        }
+
+        [TestMethod]
+        public void IsAsync_WithAsyncKeywordAndVoidReturnType()
+        {
+            var source = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {
+            async void Method()
+            {
+            }
+    }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            Assert.IsTrue(methodSymbol.IsAsync());
+        }
+
+        [TestMethod]
+        public void IsAsync_WithVoidReturnType()
+        {
+            var source = @"
+    using System;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    namespace ConsoleApplication1
+    {
+        class MyClass
+        {
+            void Method()
+            {
+            }
+    }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+            var compilation = CSharpCompilation.Create("MyCompilation", new[] { tree }, new[] { mscorlib });
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var root = tree.GetRoot();
+            var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(method);
+            Assert.IsFalse(methodSymbol.IsAsync());
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Async/AsyncMethodWithoutAsyncSuffix/AsyncMethodWithoutAsyncSuffixAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Async/AsyncMethodWithoutAsyncSuffix/AsyncMethodWithoutAsyncSuffixAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -60,15 +59,10 @@ namespace VSDiagnostics.Diagnostics.Async.AsyncMethodWithoutAsyncSuffix
                 return;
             }
 
-            if (method.Modifiers.Any(SyntaxKind.AsyncKeyword) ||
-                returnType.Type.MetadataName == typeof (Task).Name ||
-                returnType.Type.MetadataName == typeof (Task<>).Name)
+            if (declaredSymbol.IsAsync() && !method.Identifier.Text.EndsWith("Async"))
             {
-                if (!method.Identifier.Text.EndsWith("Async"))
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(),
-                        method.Identifier.Text));
-                }
+                context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(),
+                    method.Identifier.Text));
             }
         }
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -130,6 +131,13 @@ namespace VSDiagnostics.Utilities
             }
 
             return _aliasMapping.ContainsKey(type);
+        }
+
+        public static bool IsAsync(this IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.IsAsync
+                || methodSymbol.ReturnType.MetadataName == typeof(Task).Name
+                || methodSymbol.ReturnType.MetadataName == typeof(Task<>).Name;
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -133,6 +133,11 @@ namespace VSDiagnostics.Utilities
             return _aliasMapping.ContainsKey(type);
         }
 
+        /// <summary>
+        /// Determines whether or not the specified <see cref="IMethodSymbol"/> is the symbol of an asynchronous method. This can
+        /// be a method declared as async (e.g. returning <see cref="Task"/> or <see cref="Task{TResult}"/>), or a method with an
+        /// async implementation (using the <code>async</code> keyword).
+        /// </summary>
         public static bool IsAsync(this IMethodSymbol methodSymbol)
         {
             return methodSymbol.IsAsync


### PR DESCRIPTION
As discussed [here](https://github.com/Vannevelj/VSDiagnostics/pull/301#discussion_r45457711), this extracts the async checking from the `AsyncMethodWithoutAsyncSuffixAnalyzer`. I though it would be best to do that in a separate PR, to keep things small.

In this PR, I've added an extension method to tell you if a method is async, in the broadest way: either declared async (returning `Task`/`Task<>`), or implemented async (has `async` keyword).

I've called it `IsAsync()`, but that might not be the best name, since there is also an `IsAsync` property on `IMethodSymbol`, but I couldn't find a better name. Please tell me if you have suggestions ;)