### PR TITLE
fixes #288 by discarding all null interface method resolutions

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -159,7 +159,8 @@ namespace VSDiagnostics.Utilities
             foreach (var @interface in interfaces)
             {
                 var interfaceMethods =
-                    @interface.GetMembers().Select(containingType.FindImplementationForInterfaceMember);
+                    @interface.GetMembers().Select(containingType.FindImplementationForInterfaceMember).Where(x => x != null);
+
                 if (interfaceMethods.Any(method => method.Equals(methodSymbol)))
                 {
                     return true;


### PR DESCRIPTION
Can this cause an issue down the line? Perhaps. It now ignores certain symbols that might not be applicable to be ignored. I'm not 100% sure how to test this and from some real-life tests using the Roslyn codebase I did notice that every occurrence so far is fixed. If any new issues turn up, we'll tackle those when they do (though I expect it to be at most a very small amount).