### PR TITLE
Issue289

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -748,7 +748,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_CastInSeparateExpression()
+        public void TryCastWithoutUsingAsNotNull_CastInSeparateExpression_ReferenceType()
         {
             var original = @"
 using System;
@@ -784,6 +784,98 @@ namespace ConsoleApplication1
             if (oAsString != null)
             {
                 bool contains = new[] { ""test"", ""test"", ""test"" }.Contains(oAsString);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_CastInSeparateExpression_ValueType()
+        {
+            var original = @"
+using System;
+using System.Text;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is int)
+            {
+                bool contains = new[] { 5, 6, 7 }.Contains((o as int?).Value);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                bool contains = new[] { 5, 6, 7 }.Contains((oAsInt32).Value);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_CastInSeparateExpression_ValueType_NullableCollectionElements()
+        {
+            var original = @"
+using System;
+using System.Text;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is int)
+            {
+                bool contains = new int?[] { 5, 6, 7 }.Contains(o as int?);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                bool contains = new int?[] { 5, 6, 7 }.Contains(oAsInt32);
             }
         }
     }
@@ -912,6 +1004,30 @@ namespace ConsoleApplication1
 
             VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
             VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_DifferentTypes()
+        {
+            var original = @"
+using System;
+using System.Text;
+using System.Linq;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is int)
+            {
+                var x = o as string;
+            }
+        }
+    }
+}";
+            VerifyDiagnostic(original);
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -1131,7 +1131,7 @@ namespace ConsoleApplication1
         }
 
         /// <summary>
-        /// Known issue, see issue #### for more info
+        /// Known issue, see issue https://github.com/Vannevelj/VSDiagnostics/issues/379 for more info
         /// </summary>
         [TestMethod]
         [Ignore]

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -1029,5 +1029,101 @@ namespace ConsoleApplication1
 }";
             VerifyDiagnostic(original);
         }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_IsAs_UsagesOfCastedVariable()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            if (o is int)
+            {
+                var oAsInt = o as int?;
+
+                Console.Write(oAsInt);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                Console.Write(oAsInt32);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_DirectCast_UsagesOfCastedVariable()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            if (o is int)
+            {
+                var oAsInt = (int) o;
+
+                Console.Write(oAsInt);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                Console.Write(oAsInt32);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -46,7 +46,7 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = ""sample"";
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -91,8 +91,8 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = 5;
-            var oAsInt = o as int?;
-            if (oAsInt != null)
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
             {
             }
         }
@@ -138,7 +138,7 @@ namespace ConsoleApplication1
         {
             object o = ""sample"";
             Console.Write(o.GetType());
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -181,7 +181,7 @@ namespace ConsoleApplication1
     {
         void Method(object o)
         {
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -230,7 +230,7 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = ""sample"";
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -281,8 +281,8 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = 5;
-            var oAsInt = o as int?;
-            if (oAsInt != null)
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
             {
                 object irrelevant = 10.0;
                 var irrelevantAsDouble = irrelevant as double?;
@@ -373,8 +373,8 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = 5;
-            var oAsInt = o as int?;
-            if (oAsInt != null)
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
             {
             }
         }
@@ -418,8 +418,8 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = 5;
-            var oAsInt = o as int?;
-            if (oAsInt != null)
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
             {
             }
         }
@@ -489,8 +489,8 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = 5;
-            int? oAsInt = o as int?;
-            if (oAsInt != null)
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
             {
                 int? x = 10;
             }
@@ -562,8 +562,7 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = ""sample"";
-            string oAsString = o as string;
-            string anotherString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -609,7 +608,7 @@ namespace ConsoleApplication1
         void Method()
         {
             object o = ""sample"";
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null && 1 == 1)
             {
             }
@@ -652,7 +651,7 @@ namespace ConsoleApplication1
     {
         void Method(object o)
         {
-            string oAsString = o as string;
+            var oAsString = o as string;
             if (oAsString != null)
             {
             }
@@ -679,7 +678,6 @@ namespace ConsoleApplication1
         {
             if (o is string && (o as string).Length > 1)
             {
-                
             }
         }
     }
@@ -695,8 +693,8 @@ namespace ConsoleApplication1
     {
         void Method(object o)
         {
-            string oAsString = o as string;
-            if (oAsString != null && oAsString.Length > 1)
+            var oAsString = o as string;
+            if (oAsString != null && (oAsString).Length > 1)
             {
             }
         }
@@ -722,7 +720,6 @@ namespace ConsoleApplication1
         {
             if (o is string && ((string) o).Length > 1)
             {
-                
             }
         }
     }
@@ -738,8 +735,8 @@ namespace ConsoleApplication1
     {
         void Method(object o)
         {
-            string oAsString = o as string;
-            if (oAsString != null && oAsString.Length > 1)
+            var oAsString = o as string;
+            if (oAsString != null && (oAsString).Length > 1)
             {
             }
         }
@@ -756,6 +753,7 @@ namespace ConsoleApplication1
             var original = @"
 using System;
 using System.Text;
+using System.Linq;
 
 namespace ConsoleApplication1
 {
@@ -774,6 +772,7 @@ namespace ConsoleApplication1
             var expected = @"
 using System;
 using System.Text;
+using System.Linq;
 
 namespace ConsoleApplication1
 {
@@ -827,14 +826,88 @@ namespace ConsoleApplication1
     {
         void Method(object o)
         {
-            Other myVar = o as Other;
-            if (myVar != null)
+            var oAsOther = o as Other;
+            if (oAsOther != null)
             {
             }
         }
     }
 
     class Other { }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_CastUsingMethodReference()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            if (Get() is string)
+            {
+                string myVar = Get() as string;
+            }
+        }
+
+        object Get()
+        {
+            return null;
+        }
+    }
+}";
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_SplitVariableDefinitionAndAssignment()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            string myVar = null;
+            if (o is string)
+            {
+                myVar = o as string;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            string myVar = null;
+            var oAsString = o as string;
+            if (oAsString != null)
+            {
+                myVar = oAsString;
+            }
+        }
+    }
 }";
 
             VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -1049,6 +1049,7 @@ namespace ConsoleApplication1
                 var oAsInt = o as int?;
 
                 Console.Write(oAsInt);
+                Console.Write(oAsInt);
             }
         }
     }
@@ -1068,6 +1069,7 @@ namespace ConsoleApplication1
             var oAsInt32 = o as int?;
             if (oAsInt32 != null)
             {
+                Console.Write(oAsInt32);
                 Console.Write(oAsInt32);
             }
         }
@@ -1097,6 +1099,7 @@ namespace ConsoleApplication1
                 var oAsInt = (int) o;
 
                 Console.Write(oAsInt);
+                Console.Write(oAsInt);
             }
         }
     }
@@ -1116,6 +1119,7 @@ namespace ConsoleApplication1
             var oAsInt32 = o as int?;
             if (oAsInt32 != null)
             {
+                Console.Write(oAsInt32);
                 Console.Write(oAsInt32);
             }
         }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -14,7 +14,7 @@ namespace VSDiagnostics.Test.Tests.General
         protected override CodeFixProvider CodeFixProvider => new TryCastWithoutUsingAsNotNullCodeFix();
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithIsAs_AndReferenceType()
+        public void TryCastWithoutUsingAsNotNull_IsAs_AndReferenceType()
         {
             var original = @"
 using System;
@@ -59,7 +59,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithIsAs_AndValueType()
+        public void TryCastWithoutUsingAsNotNull_IsAs_AndValueType()
         {
             var original = @"
 using System;
@@ -104,7 +104,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithIsAs_AndObjectIsUsedBeforeIs()
+        public void TryCastWithoutUsingAsNotNull_IsAs_AndObjectIsUsedBeforeIs()
         {
             var original = @"
 using System;
@@ -151,7 +151,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithIsAs_AndObjectIsMethodParameter()
+        public void TryCastWithoutUsingAsNotNull_IsAs_AndObjectIsMethodParameter()
         {
             var original = @"
 using System;
@@ -194,7 +194,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithIsAs_AndElseClause()
+        public void TryCastWithoutUsingAsNotNull_IsAs_AndElseClause()
         {
             var original = @"
 using System;
@@ -247,7 +247,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithMultipleCasts()
+        public void TryCastWithoutUsingAsNotNull_MultipleIrrelevantCasts()
         {
             var original = @"
 using System;
@@ -296,7 +296,52 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithDirectCast()
+        public void TryCastWithoutUsingAsNotNull_DirectCast_ReferenceType()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""test"";
+            if (o is string)
+            {
+                var oAsString = (string) o;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""test"";
+            var oAsString = o as string;
+            if (oAsString != null)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_DirectCast_Struct()
         {
             var original = @"
 using System;
@@ -317,7 +362,72 @@ namespace ConsoleApplication1
     }
 }";
 
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            var oAsInt = o as int?;
+            if (oAsInt != null)
+            {
+            }
+        }
+    }
+}";
+
             VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_DirectCast_NullableStruct()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            if (o is int)
+            {
+                var oAsInt = (int?) o;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            var oAsInt = o as int?;
+            if (oAsInt != null)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
         }
 
         [TestMethod]
@@ -347,7 +457,7 @@ namespace ConsoleApplication1
         }
 
         [TestMethod]
-        public void TryCastWithoutUsingAsNotNull_WithChainedVariableDeclaration()
+        public void TryCastWithoutUsingAsNotNull_ChainedVariableDeclaration()
         {
             var original = @"
 using System;
@@ -383,6 +493,125 @@ namespace ConsoleApplication1
             if (oAsInt != null)
             {
                 int? x = 10;
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_TryCastNullCheck()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            int? oAsInt = o as int?;
+            if (oAsInt != null)
+            {
+
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_MultipleRelevantCasts()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""sample"";
+            if (o is string)
+            {
+                string oAsString = o as string;
+                string anotherString = o as string;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""sample"";
+            string oAsString = o as string;
+            string anotherString = o as string;
+            if (oAsString != null)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"),
+                string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_MultipleIfConditions()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""sample"";
+            if (o is string && 1 == 1)
+            {
+                string oAsString = o as string;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = ""sample"";
+            string oAsString = o as string;
+            if (oAsString != null && 1 == 1)
+            {
             }
         }
     }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -1129,5 +1129,163 @@ namespace ConsoleApplication1
             VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
             VerifyFix(original, expected);
         }
+
+        /// <summary>
+        /// Known issue, see issue #### for more info
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public void TryCastWithoutUsingAsNotNull_AnonymousTypeRenaming()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            if (o is int)
+            {
+                var x = (int) o;
+                var y = new { x };
+                var z = y.x;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            object o = 5;
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                var y = new { oAsInt32 };
+                var z = y.oAsInt32;
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_ConflictingLocalReferringToField()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        private int oAsInt32;
+
+        void Method(object o)
+        {
+            if (o is int)
+            {
+                var someVar = (int)o;
+
+                Console.Write(someVar);
+                Console.Write(oAsInt32);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        private int oAsInt32;
+
+        void Method(object o)
+        {
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                Console.Write(oAsInt32);
+                Console.Write(this.oAsInt32);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_ConflictingLocalExplicitlyReferringToField()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        private int oAsInt32;
+
+        void Method(object o)
+        {
+            if (o is int)
+            {
+                var someVar = (int)o;
+
+                Console.Write(someVar);
+                Console.Write(this.oAsInt32);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        private int oAsInt32;
+
+        void Method(object o)
+        {
+            var oAsInt32 = o as int?;
+            if (oAsInt32 != null)
+            {
+                Console.Write(oAsInt32);
+                Console.Write(this.oAsInt32);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TryCastUsingAsNotNullInsteadOfIsAsTests.cs
@@ -620,5 +620,225 @@ namespace ConsoleApplication1
             VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
             VerifyFix(original, expected);
         }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_ReferencingParameter()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is string)
+            {
+                string oAsString = o as string;
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            string oAsString = o as string;
+            if (oAsString != null)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_AsCastInIfCondition()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is string && (o as string).Length > 1)
+            {
+                
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            string oAsString = o as string;
+            if (oAsString != null && oAsString.Length > 1)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_DirectCastInIfCondition()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is string && ((string) o).Length > 1)
+            {
+                
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            string oAsString = o as string;
+            if (oAsString != null && oAsString.Length > 1)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_CastInSeparateExpression()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is string)
+            {
+                bool contains = new[] { ""test"", ""test"", ""test"" }.Contains(o as string);
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            var oAsString = o as string;
+            if (oAsString != null)
+            {
+                bool contains = new[] { ""test"", ""test"", ""test"" }.Contains(oAsString);
+            }
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
+
+        [TestMethod]
+        public void TryCastWithoutUsingAsNotNull_CastToSelfdefinedType()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            if (o is Other)
+            {
+                Other myVar = o as Other;
+            }
+        }
+    }
+
+    class Other { }
+}";
+
+            var expected = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method(object o)
+        {
+            Other myVar = o as Other;
+            if (myVar != null)
+            {
+            }
+        }
+    }
+
+    class Other { }
+}";
+
+            VerifyDiagnostic(original, string.Format(TryCastWithoutUsingAsNotNullAnalyzer.Rule.MessageFormat.ToString(), "o"));
+            VerifyFix(original, expected);
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
@@ -38,6 +38,11 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                 return;
             }
             var isIdentifier = isIdentifierExpression.Identifier.ValueText;
+            var isType = context.SemanticModel.GetTypeInfo(isExpression.Right).Type;
+            if (isType == null)
+            {
+                return;
+            }
 
             var ifStatement = isExpression.AncestorsAndSelf().OfType<IfStatementSyntax>().FirstOrDefault();
             if (ifStatement == null)
@@ -56,11 +61,37 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                                              .Concat(ifStatement.Condition.DescendantNodesAndSelf())
                                              .OfType<CastExpressionSyntax>();
 
-            Action<string> checkIdentifier = bodyIdentifier =>
+            Action reportDiagnostic = () => context.ReportDiagnostic(Diagnostic.Create(Rule, isExpression.GetLocation(), isIdentifier));
+
+            Action<string, TypeInfo> checkRequirements = (bodyIdentifier, castedType) =>
             {
+                if (castedType.Type == null)
+                {
+                    return;
+                }
+
                 if (bodyIdentifier == isIdentifier)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Rule, isExpression.GetLocation(), isIdentifier));
+                    // If the cast is of type Nullable<T> then we have to look at the generic argument
+                    // A direct cast and an 'is' operator will use 'int' but the corresponding 'as' cast uses 'Nullable<int>'
+                    if (castedType.Type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                    {
+                        var nullableType = castedType.Type as INamedTypeSymbol;
+                        var argument = nullableType?.TypeArguments.FirstOrDefault();
+                        if (argument == null)
+                        {
+                            return;
+                        }
+
+                        if (argument.Equals(isType))
+                        {
+                            reportDiagnostic();
+                        }
+                    }
+                    else if (castedType.Type.Equals(isType))
+                    {
+                        reportDiagnostic();
+                    }
                 }
             };
 
@@ -70,7 +101,8 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                 var binaryIdentifier = binaryExpression?.Left as IdentifierNameSyntax;
                 if (binaryIdentifier != null)
                 {
-                    checkIdentifier(binaryIdentifier.Identifier.ValueText);
+                    var castedType = context.SemanticModel.GetTypeInfo(binaryExpression.Right);
+                    checkRequirements(binaryIdentifier.Identifier.ValueText, castedType);
                     continue;
                 }
 
@@ -78,7 +110,9 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                 var castIdentifier = castExpression?.Expression as IdentifierNameSyntax;
                 if (castIdentifier != null)
                 {
-                    checkIdentifier(castIdentifier.Identifier.ValueText);
+                    var castedType = context.SemanticModel.GetTypeInfo(castExpression.Type);
+                    checkRequirements(castIdentifier.Identifier.ValueText, castedType);
+                    continue;
                 }
             }
         }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
@@ -47,11 +47,13 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
 
             var asExpressions = ifStatement.Statement
                                            .DescendantNodes()
+                                           .Concat(ifStatement.Condition.DescendantNodesAndSelf())
                                            .OfType<BinaryExpressionSyntax>()
                                            .Where(x => x.OperatorToken.IsKind(SyntaxKind.AsKeyword));
 
             var castExpressions = ifStatement.Statement
                                              .DescendantNodes()
+                                             .Concat(ifStatement.Condition.DescendantNodesAndSelf())
                                              .OfType<CastExpressionSyntax>();
 
             Action<string> checkIdentifier = bodyIdentifier =>


### PR DESCRIPTION
Fixes #289 but has an outstanding issue at #379 

This PR fixes a lot of bugs, added many tests and introduces new functionality. The original problem existed in the fact that the analyzer triggered for casts but the code fix only handled `as` statements (I know, horrible). This PR allows you to handle both casts and `as` statements as self-contained variable declarations, part of a larger group of variable declarators or as an expression surrounded by an invocation. It will create a new variable outside the `if` statement and apply the 'renamer' attribute so you get the renaming dialog. All appropriate casts inside one `if` statement will be consolidated together to the same casted variable with each of their usages renamed to this new variable.