### PR TITLE
Remove Linq from Analyzers

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeAnalyzer.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute
 {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/EnumCanHaveFlagsAttribute/EnumCanHaveFlagsAttributeAnalyzer.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute
 {
@@ -23,23 +23,22 @@ namespace VSDiagnostics.Diagnostics.Attributes.EnumCanHaveFlagsAttribute
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeCSharpSymbol, SyntaxKind.EnumDeclaration);
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSymbol, SyntaxKind.EnumDeclaration);
 
-        private void AnalyzeCSharpSymbol(SyntaxNodeAnalysisContext context)
+        private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var enumDeclaration = (EnumDeclarationSyntax) context.Node;
 
-            // enum must not already have flags attribute
-            if (enumDeclaration.AttributeLists.Any(
-                a => a.Attributes.Any(
-                    t =>
-                    {
-                        var symbol = context.SemanticModel.GetSymbolInfo(t).Symbol;
-
-                        return symbol == null || symbol.ContainingType.MetadataName == typeof(FlagsAttribute).Name;
-                    })))
+            foreach (var list in enumDeclaration.AttributeLists)
             {
-                return;
+                foreach (var attribute in list.Attributes)
+                {
+                    var symbol = context.SemanticModel.GetSymbolInfo(attribute).Symbol;
+                    if (symbol == null || symbol.ContainingType.MetadataName == typeof (FlagsAttribute).Name)
+                    {
+                        return;
+                    }
+                }
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, enumDeclaration.GetLocation()));

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
@@ -79,7 +79,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
 
             var enumName = context.SemanticModel.GetDeclaredSymbol(declarationExpression).Name;
             var enumMemberDeclarations =
-                declarationExpression.ChildNodes().SyntaxNodeOfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
+                declarationExpression.ChildNodes().OfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
 
             foreach (var member in enumMemberDeclarations)
             {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
 {
@@ -79,7 +79,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
 
             var enumName = context.SemanticModel.GetDeclaredSymbol(declarationExpression).Name;
             var enumMemberDeclarations =
-                declarationExpression.ChildNodes().NonLinqOfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
+                declarationExpression.ChildNodes().SyntaxNodeOfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
 
             foreach (var member in enumMemberDeclarations)
             {
@@ -165,7 +165,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
                         }
                     }
 
-                    if (descendantNodes.NonLinqAny() && all)
+                    if (descendantNodes.Any() && all)
                     {
                         continue;
                     }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/FlagsEnumValuesAreNotPowersOfTwo/FlagsEnumValuesAreNotPowersOfTwoAnalyzer.cs
@@ -79,7 +79,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
 
             var enumName = context.SemanticModel.GetDeclaredSymbol(declarationExpression).Name;
             var enumMemberDeclarations =
-                declarationExpression.ChildNodes().OfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
+                declarationExpression.ChildNodes().NonLinqOfType<EnumMemberDeclarationSyntax>(SyntaxKind.EnumMemberDeclaration);
 
             foreach (var member in enumMemberDeclarations)
             {
@@ -165,7 +165,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.FlagsEnumValuesAreNotPowersOfTwo
                         }
                     }
 
-                    if (descendantNodes.Any() && all)
+                    if (descendantNodes.NonLinqAny() && all)
                     {
                         continue;
                     }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
@@ -32,8 +32,9 @@ namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMem
 
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
-            var methodDeclaration = (MethodDeclarationSyntax) context.Node;
-            var parentClass = methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
+            var methodDeclaration = (MethodDeclarationSyntax)context.Node;
+            var parentClass = methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+            var typeSymbol = context.SemanticModel.GetDeclaredSymbol(parentClass);
 
             // class must implement INotifyPropertyChanged
             if (!typeSymbol.ImplementsInterfaceOrBaseClass(typeof(INotifyPropertyChanged)))

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
@@ -33,7 +33,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMem
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var methodDeclaration = (MethodDeclarationSyntax) context.Node;
-            var parentClass = methodDeclaration.Ancestors().SyntaxNodeOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
+            var parentClass = methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
 
             // class must implement INotifyPropertyChanged
             if (!parentClass.ImplementsInterface(context.SemanticModel, typeof(INotifyPropertyChanged)))

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
@@ -33,7 +33,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMem
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var methodDeclaration = (MethodDeclarationSyntax)context.Node;
-            var parentClass = methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+            var parentClass = methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
             var typeSymbol = context.SemanticModel.GetDeclaredSymbol(parentClass);
 
             // class must implement INotifyPropertyChanged

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMemberName
 {
@@ -33,8 +33,7 @@ namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMem
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var methodDeclaration = (MethodDeclarationSyntax) context.Node;
-            var parentClass = methodDeclaration.Ancestors().NonLinqOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).NonLinqFirstOrDefault();
-
+            var parentClass = methodDeclaration.Ancestors().SyntaxNodeOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
 
             // class must implement INotifyPropertyChanged
             if (!parentClass.ImplementsInterface(context.SemanticModel, typeof(INotifyPropertyChanged)))

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/ArgumentExceptionWithoutNameofOperator/ArgumentExceptionWithoutNameofOperatorAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/ArgumentExceptionWithoutNameofOperator/ArgumentExceptionWithoutNameofOperatorAnalyzer.cs
@@ -46,16 +46,15 @@ namespace VSDiagnostics.Diagnostics.Exceptions.ArgumentExceptionWithoutNameofOpe
 
                 foreach (var argument in objectCreationExpression.ArgumentList.Arguments)
                 {
-                    var expression = argument.Expression as LiteralExpressionSyntax;
-                    if (expression != null)
+                    if (argument.Expression is LiteralExpressionSyntax)
                     {
-                        arguments.Add(expression);
+                        arguments.Add((LiteralExpressionSyntax)argument.Expression);
                     }
                 }
 
                 var methodParameters =
                     objectCreationExpression.Ancestors()
-                                            .SyntaxNodeOfType<MethodDeclarationSyntax>(SyntaxKind.MethodDeclaration)
+                                            .OfType<MethodDeclarationSyntax>(SyntaxKind.MethodDeclaration)
                                             .FirstOrDefault()?
                                             .ParameterList.Parameters;
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/ArgumentExceptionWithoutNameofOperator/ArgumentExceptionWithoutNameofOperatorAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/ArgumentExceptionWithoutNameofOperator/ArgumentExceptionWithoutNameofOperatorAnalyzer.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Exceptions.ArgumentExceptionWithoutNameofOperator
 {
@@ -55,8 +55,8 @@ namespace VSDiagnostics.Diagnostics.Exceptions.ArgumentExceptionWithoutNameofOpe
 
                 var methodParameters =
                     objectCreationExpression.Ancestors()
-                                            .NonLinqOfType<MethodDeclarationSyntax>(SyntaxKind.MethodDeclaration)
-                                            .NonLinqFirstOrDefault()?
+                                            .SyntaxNodeOfType<MethodDeclarationSyntax>(SyntaxKind.MethodDeclaration)
+                                            .FirstOrDefault()?
                                             .ParameterList.Parameters;
 
                 // Exception is declared outside a method

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyArgumentException/EmptyArgumentExceptionAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyArgumentException/EmptyArgumentExceptionAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -41,7 +40,7 @@ namespace VSDiagnostics.Diagnostics.Exceptions.EmptyArgumentException
                 return;
             }
 
-            if (!expression.ArgumentList.ChildNodes().Any())
+            if (!expression.ArgumentList.ChildNodes().NonLinqAny())
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rule, expression.GetLocation()));
             }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyCatchClause/EmptyCatchClauseAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyCatchClause/EmptyCatchClauseAnalyzer.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Exceptions.EmptyCatchClause
 {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyCatchClause/EmptyCatchClauseAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/EmptyCatchClause/EmptyCatchClauseAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Exceptions.EmptyCatchClause
 {
@@ -37,9 +37,12 @@ namespace VSDiagnostics.Diagnostics.Exceptions.EmptyCatchClause
                 return;
             }
 
-            if (catchClause.Block.CloseBraceToken.LeadingTrivia.Any(x => x.IsCommentTrivia()))
+            foreach (var trivia in catchClause.Block.CloseBraceToken.LeadingTrivia)
             {
-                return;
+                if (trivia.IsCommentTrivia())
+                {
+                    return;
+                }
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, catchClause.CatchKeyword.GetLocation()));

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
@@ -38,7 +38,7 @@ namespace VSDiagnostics.Diagnostics.Exceptions.RethrowExceptionWithoutLosingStac
                 return;
             }
 
-            var catchClause = throwStatement.Ancestors().NonLinqOfType<CatchClauseSyntax>(SyntaxKind.CatchClause).NonLinqFirstOrDefault();
+            var catchClause = throwStatement.Ancestors().SyntaxNodeOfType<CatchClauseSyntax>(SyntaxKind.CatchClause).NonLinqFirstOrDefault();
 
             // Code is in an incomplete state (user is typing the catch clause but hasn't typed the identifier yet)
             var exceptionIdentifier = catchClause?.Declaration?.Identifier;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
@@ -39,7 +39,7 @@ namespace VSDiagnostics.Diagnostics.Exceptions.RethrowExceptionWithoutLosingStac
                 return;
             }
 
-            var catchClause = throwStatement.Ancestors().SyntaxNodeOfType<CatchClauseSyntax>(SyntaxKind.CatchClause).FirstOrDefault();
+            var catchClause = throwStatement.Ancestors().OfType<CatchClauseSyntax>(SyntaxKind.CatchClause).FirstOrDefault();
 
             // Code is in an incomplete state (user is typing the catch clause but hasn't typed the identifier yet)
             var exceptionIdentifier = catchClause?.Declaration?.Identifier;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Exceptions/RethrowExceptionWithoutLosingStacktrace/RethrowExceptionWithoutLosingStacktraceAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -39,7 +38,7 @@ namespace VSDiagnostics.Diagnostics.Exceptions.RethrowExceptionWithoutLosingStac
                 return;
             }
 
-            var catchClause = throwStatement.Ancestors().OfType<CatchClauseSyntax>().FirstOrDefault();
+            var catchClause = throwStatement.Ancestors().NonLinqOfType<CatchClauseSyntax>(SyntaxKind.CatchClause).NonLinqFirstOrDefault();
 
             // Code is in an incomplete state (user is typing the catch clause but hasn't typed the identifier yet)
             var exceptionIdentifier = catchClause?.Declaration?.Identifier;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/ExplicitAccessModifiers/ExplicitAccessModifiersAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/ExplicitAccessModifiers/ExplicitAccessModifiersAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
 {
@@ -54,7 +54,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.ClassDeclaration))
             {
                 var declarationExpression = (ClassDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -67,7 +67,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.StructDeclaration))
             {
                 var declarationExpression = (StructDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -80,7 +80,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EnumDeclaration))
             {
                 var declarationExpression = (EnumDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -93,7 +93,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.DelegateDeclaration))
             {
                 var declarationExpression = (DelegateDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -106,7 +106,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.InterfaceDeclaration))
             {
                 var declarationExpression = (InterfaceDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -119,7 +119,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.FieldDeclaration))
             {
                 var declarationExpression = (FieldDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Rule, declarationExpression.GetLocation(),
                         "private"));
@@ -129,7 +129,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.PropertyDeclaration))
             {
                 var declarationExpression = (PropertyDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())) &&
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =
@@ -143,8 +143,8 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.MethodDeclaration))
             {
                 var declarationExpression = (MethodDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())) &&
-                    declarationExpression.Modifiers.All(m => m.Kind() != SyntaxKind.PartialKeyword) &&
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
+                    !declarationExpression.Modifiers.NonLinqContains(SyntaxKind.PartialKeyword) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =
@@ -158,9 +158,8 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.ConstructorDeclaration))
             {
                 var declarationExpression = (ConstructorDeclarationSyntax) context.Node;
-                if (
-                    !declarationExpression.Modifiers.Any(
-                        m => _accessModifierKinds.Contains(m.Kind()) || m.Kind() == SyntaxKind.StaticKeyword))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
+                    !declarationExpression.Modifiers.NonLinqContains(SyntaxKind.StaticKeyword))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -173,7 +172,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EventFieldDeclaration))
             {
                 var declarationExpression = (EventFieldDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Rule, declarationExpression.GetLocation(),
                         "private"));
@@ -183,7 +182,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EventDeclaration))
             {
                 var declarationExpression = (EventDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())))
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -196,7 +195,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.IndexerDeclaration))
             {
                 var declarationExpression = (IndexerDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.Any(m => _accessModifierKinds.Contains(m.Kind())) &&
+                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/ExplicitAccessModifiers/ExplicitAccessModifiersAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/ExplicitAccessModifiers/ExplicitAccessModifiersAnalyzer.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
 {
@@ -54,7 +53,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.ClassDeclaration))
             {
                 var declarationExpression = (ClassDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -67,7 +66,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.StructDeclaration))
             {
                 var declarationExpression = (StructDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -80,7 +79,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EnumDeclaration))
             {
                 var declarationExpression = (EnumDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -93,7 +92,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.DelegateDeclaration))
             {
                 var declarationExpression = (DelegateDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -106,7 +105,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.InterfaceDeclaration))
             {
                 var declarationExpression = (InterfaceDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -119,7 +118,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.FieldDeclaration))
             {
                 var declarationExpression = (FieldDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Rule, declarationExpression.GetLocation(),
                         "private"));
@@ -129,7 +128,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.PropertyDeclaration))
             {
                 var declarationExpression = (PropertyDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =
@@ -143,8 +142,8 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.MethodDeclaration))
             {
                 var declarationExpression = (MethodDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
-                    !declarationExpression.Modifiers.NonLinqContains(SyntaxKind.PartialKeyword) &&
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds) &&
+                    !declarationExpression.Modifiers.Contains(SyntaxKind.PartialKeyword) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =
@@ -158,8 +157,8 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.ConstructorDeclaration))
             {
                 var declarationExpression = (ConstructorDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
-                    !declarationExpression.Modifiers.NonLinqContains(SyntaxKind.StaticKeyword))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds) &&
+                    !declarationExpression.Modifiers.Contains(SyntaxKind.StaticKeyword))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -172,7 +171,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EventFieldDeclaration))
             {
                 var declarationExpression = (EventFieldDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Rule, declarationExpression.GetLocation(),
                         "private"));
@@ -182,7 +181,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.EventDeclaration))
             {
                 var declarationExpression = (EventDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds))
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds))
                 {
                     var accessibility =
                         context.SemanticModel.GetDeclaredSymbol(declarationExpression).DeclaredAccessibility;
@@ -195,7 +194,7 @@ namespace VSDiagnostics.Diagnostics.General.ExplicitAccessModifiers
             if (context.Node.IsKind(SyntaxKind.IndexerDeclaration))
             {
                 var declarationExpression = (IndexerDeclarationSyntax) context.Node;
-                if (!declarationExpression.Modifiers.NonLinqContainsAny(_accessModifierKinds) &&
+                if (!declarationExpression.Modifiers.ContainsAny(_accessModifierKinds) &&
                     declarationExpression.ExplicitInterfaceSpecifier == null)
                 {
                     var accessibility =

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/LoopedRandomInstantiation/LoopedRandomInstantiationAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/LoopedRandomInstantiation/LoopedRandomInstantiationAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -45,7 +44,7 @@ namespace VSDiagnostics.Diagnostics.General.LoopedRandomInstantiation
             SyntaxNode currentNode = variableDeclaration;
             while (!currentNode.IsKind(SyntaxKind.ClassDeclaration))
             {
-                if (_loopTypes.Contains(currentNode.Kind()))
+                if (_loopTypes.NonLinqContains(currentNode.Kind()))
                 {
                     foreach (var declarator in variableDeclaration.Variables)
                     {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NonEncapsulatedOrMutableField/NonEncapsulatedOrMutableFieldAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NonEncapsulatedOrMutableField/NonEncapsulatedOrMutableFieldAnalyzer.cs
@@ -29,13 +29,13 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
             var fieldDeclaration = (FieldDeclarationSyntax) context.Node;
 
             // Don't handle (semi-)immutable fields
-            if (fieldDeclaration.Modifiers.ContainsAny(new [] {SyntaxKind.ConstKeyword, SyntaxKind.ReadOnlyKeyword}))
+            if (fieldDeclaration.Modifiers.ContainsAny(SyntaxKind.ConstKeyword, SyntaxKind.ReadOnlyKeyword))
             {
                 return;
             }
 
             // Only handle public, internal and protected internal fields
-            if (!fieldDeclaration.Modifiers.ContainsAny(new[] {SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword}))
+            if (!fieldDeclaration.Modifiers.ContainsAny(SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword))
             {
                 return;
             }
@@ -69,7 +69,7 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
             // In this scenario our analyzer is triggered on the field in class X and won't find any references inside that syntax tree (assuming separate files)
             // However it won't find any ref/out usages there so it will create the diagnostic -- which obviously isn't supposed to happen because the other syntax tree DOES contain that
             // However until this ability is added, we'll just have to live with it
-            var outerClass = context.Node.Ancestors().SyntaxNodeOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).LastOrDefault();
+            var outerClass = context.Node.Ancestors().OfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).LastOrDefault();
             if (outerClass != null)
             {
                 var semanticModel = context.SemanticModel;
@@ -78,14 +78,14 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
                 {
                     var fieldSymbol = semanticModel.GetDeclaredSymbol(variable);
 
-                    foreach (var descendant in outerClass.DescendantNodes().SyntaxNodeOfType<IdentifierNameSyntax>(SyntaxKind.IdentifierName))
+                    foreach (var descendant in outerClass.DescendantNodes().OfType<IdentifierNameSyntax>(SyntaxKind.IdentifierName))
                     {
                         var descendentSymbol = semanticModel.GetSymbolInfo(descendant).Symbol;
                         if (descendentSymbol != null && descendentSymbol.Equals(fieldSymbol))
                         {
                             // The field is being referenced
                             // Next we check whether it is referenced as an argument and passed by ref/out
-                            var argument = descendant.AncestorsAndSelf().SyntaxNodeOfType<ArgumentSyntax>(SyntaxKind.Argument).FirstOrDefault();
+                            var argument = descendant.AncestorsAndSelf().OfType<ArgumentSyntax>(SyntaxKind.Argument).FirstOrDefault();
                             if (argument != null && !argument.RefOrOutKeyword.IsMissing)
                             {
                                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NonEncapsulatedOrMutableField/NonEncapsulatedOrMutableFieldAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NonEncapsulatedOrMutableField/NonEncapsulatedOrMutableFieldAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
 {
@@ -29,15 +29,13 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
             var fieldDeclaration = (FieldDeclarationSyntax) context.Node;
 
             // Don't handle (semi-)immutable fields
-            if (fieldDeclaration.Modifiers.Any(
-                x => x.IsKind(SyntaxKind.ConstKeyword) || x.IsKind(SyntaxKind.ReadOnlyKeyword)))
+            if (fieldDeclaration.Modifiers.NonLinqContainsAny(new [] {SyntaxKind.ConstKeyword, SyntaxKind.ReadOnlyKeyword}))
             {
                 return;
             }
 
             // Only handle public, internal and protected internal fields
-            if (!fieldDeclaration.Modifiers.Any(
-                x => x.IsKind(SyntaxKind.PublicKeyword) || x.IsKind(SyntaxKind.InternalKeyword)))
+            if (!fieldDeclaration.Modifiers.NonLinqContainsAny(new[] {SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword}))
             {
                 return;
             }
@@ -71,7 +69,7 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
             // In this scenario our analyzer is triggered on the field in class X and won't find any references inside that syntax tree (assuming separate files)
             // However it won't find any ref/out usages there so it will create the diagnostic -- which obviously isn't supposed to happen because the other syntax tree DOES contain that
             // However until this ability is added, we'll just have to live with it
-            var outerClass = context.Node.Ancestors().OfType<ClassDeclarationSyntax>().LastOrDefault();
+            var outerClass = context.Node.Ancestors().NonLinqOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).NonLinqLastOrDefault();
             if (outerClass != null)
             {
                 var semanticModel = context.SemanticModel;
@@ -80,14 +78,14 @@ namespace VSDiagnostics.Diagnostics.General.NonEncapsulatedOrMutableField
                 {
                     var fieldSymbol = semanticModel.GetDeclaredSymbol(variable);
 
-                    foreach (var descendant in outerClass.DescendantNodes().OfType<IdentifierNameSyntax>())
+                    foreach (var descendant in outerClass.DescendantNodes().NonLinqOfType<IdentifierNameSyntax>(SyntaxKind.IdentifierName))
                     {
                         var descendentSymbol = semanticModel.GetSymbolInfo(descendant).Symbol;
                         if (descendentSymbol != null && descendentSymbol.Equals(fieldSymbol))
                         {
                             // The field is being referenced
                             // Next we check whether it is referenced as an argument and passed by ref/out
-                            var argument = descendant.AncestorsAndSelf().OfType<ArgumentSyntax>().FirstOrDefault();
+                            var argument = descendant.AncestorsAndSelf().NonLinqOfType<ArgumentSyntax>(SyntaxKind.Argument).NonLinqFirstOrDefault();
                             if (argument != null && !argument.RefOrOutKeyword.IsMissing)
                             {
                                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NullableToShorthand/NullableToShorthandAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NullableToShorthand/NullableToShorthandAnalyzer.cs
@@ -26,7 +26,7 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var argumentList = (GenericNameSyntax) context.Node;
-            if (argumentList.TypeArgumentList.Arguments.NonLinqOfType<OmittedTypeArgumentSyntax>(SyntaxKind.OmittedTypeArgument).NonLinqAny())
+            if (argumentList.TypeArgumentList.Arguments.SyntaxNodeOfType<OmittedTypeArgumentSyntax>(SyntaxKind.OmittedTypeArgument).NonLinqAny())
             {
                 return;
             }
@@ -74,7 +74,7 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
 
                 if (parentNode == null)
                 {
-                    parentNode = context.Node.AncestorsAndSelf().NonLinqOfType<ExpressionStatementSyntax>(SyntaxKind.ExpressionStatement).NonLinqFirstOrDefault();
+                    parentNode = context.Node.AncestorsAndSelf().SyntaxNodeOfType<ExpressionStatementSyntax>(SyntaxKind.ExpressionStatement).NonLinqFirstOrDefault();
 
                     if (parentNode == null)
                     {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NullableToShorthand/NullableToShorthandAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/NullableToShorthand/NullableToShorthandAnalyzer.cs
@@ -27,7 +27,7 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
         private void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
             var argumentList = (GenericNameSyntax) context.Node;
-            if (argumentList.TypeArgumentList.Arguments.SyntaxNodeOfType<OmittedTypeArgumentSyntax>(SyntaxKind.OmittedTypeArgument).Any())
+            if (argumentList.TypeArgumentList.Arguments.OfType<OmittedTypeArgumentSyntax>(SyntaxKind.OmittedTypeArgument).Any())
             {
                 return;
             }
@@ -75,7 +75,7 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
 
                 if (parentNode == null)
                 {
-                    parentNode = context.Node.AncestorsAndSelf().SyntaxNodeOfType<ExpressionStatementSyntax>(SyntaxKind.ExpressionStatement).FirstOrDefault();
+                    parentNode = context.Node.AncestorsAndSelf().OfType<ExpressionStatementSyntax>(SyntaxKind.ExpressionStatement).FirstOrDefault();
 
                     if (parentNode == null)
                     {
@@ -85,7 +85,6 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
 
                 if (parentNode.Kind() == SyntaxKind.LocalDeclarationStatement)
                 {
-                    // ReSharper disable once PossibleInvalidCastException
                     identifier = ((LocalDeclarationStatementSyntax) parentNode).Declaration?
                                                                                .Variables
                                                                                .FirstOrDefault()?
@@ -94,7 +93,6 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
                 }
                 else if (parentNode.Kind() == SyntaxKind.FieldDeclaration)
                 {
-                    // ReSharper disable once PossibleInvalidCastException
                     identifier = ((FieldDeclarationSyntax) parentNode).Declaration?
                                                                       .Variables
                                                                       .FirstOrDefault()?
@@ -103,17 +101,14 @@ namespace VSDiagnostics.Diagnostics.General.NullableToShorthand
                 }
                 else if (parentNode.Kind() == SyntaxKind.Parameter)
                 {
-                    // ReSharper disable once PossibleInvalidCastException
                     identifier = ((ParameterSyntax) parentNode).Identifier.Text;
                 }
                 else if (parentNode.Kind() == SyntaxKind.TypeParameter)
                 {
-                    // ReSharper disable once PossibleInvalidCastException
                     identifier = ((TypeParameterSyntax) parentNode).Identifier.Text;
                 }
                 else if (parentNode.Kind() == SyntaxKind.PropertyDeclaration)
                 {
-                    // ReSharper disable once PossibleInvalidCastException
                     identifier = ((PropertyDeclarationSyntax) parentNode).Identifier.Text;
                 }
                 else

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/OnPropertyChangedWithoutNameOfOperator/OnPropertyChangedWithoutNameOfOperatorAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/OnPropertyChangedWithoutNameOfOperator/OnPropertyChangedWithoutNameOfOperatorAnalyzer.cs
@@ -61,7 +61,7 @@ namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperat
             }
 
             // We use the descendent nodes in case it's wrapped in another level. For example: OnPropertyChanged(((nameof(MyProperty))))
-            foreach (var expression in invokedProperty.DescendantNodesAndSelf().SyntaxNodeOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression))
+            foreach (var expression in invokedProperty.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression))
             {
                 if (expression.IsNameofInvocation())
                 {
@@ -77,7 +77,7 @@ namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperat
 
             // Get all the properties defined in this type
             // We can't just get all the descendents of the classdeclaration because that would pass by some of a partial class' properties
-            var classDeclaration = invocation.Ancestors().SyntaxNodeOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
+            var classDeclaration = invocation.Ancestors().OfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
             if (classDeclaration == null)
             {
                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/OnPropertyChangedWithoutNameOfOperator/OnPropertyChangedWithoutNameOfOperatorAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/OnPropertyChangedWithoutNameOfOperator/OnPropertyChangedWithoutNameOfOperatorAnalyzer.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperator
 {
@@ -61,7 +61,7 @@ namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperat
             }
 
             // We use the descendent nodes in case it's wrapped in another level. For example: OnPropertyChanged(((nameof(MyProperty))))
-            foreach (var expression in invokedProperty.DescendantNodesAndSelf().NonLinqOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression))
+            foreach (var expression in invokedProperty.DescendantNodesAndSelf().SyntaxNodeOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression))
             {
                 if (expression.IsNameofInvocation())
                 {
@@ -77,7 +77,7 @@ namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperat
 
             // Get all the properties defined in this type
             // We can't just get all the descendents of the classdeclaration because that would pass by some of a partial class' properties
-            var classDeclaration = invocation.Ancestors().NonLinqOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).NonLinqFirstOrDefault();
+            var classDeclaration = invocation.Ancestors().SyntaxNodeOfType<ClassDeclarationSyntax>(SyntaxKind.ClassDeclaration).FirstOrDefault();
             if (classDeclaration == null)
             {
                 return;
@@ -95,7 +95,7 @@ namespace VSDiagnostics.Diagnostics.General.OnPropertyChangedWithoutNameOfOperat
                 {
                     // The original Linq was `Last()`.  I used `LastOrDefault()` just because I didn't feel the need to implement a
                     // version to throw an `InvalidOperationException()` rather than a `NullReferenceException()` in this case.
-                    var location = invokedProperty.Expression.DescendantNodesAndSelf().NonLinqLastOrDefault().GetLocation();
+                    var location = invokedProperty.Expression.DescendantNodesAndSelf().LastOrDefault().GetLocation();
                     var data = ImmutableDictionary.CreateRange(new[]
                     {
                         new KeyValuePair<string, string>("parameterName", property.Name),

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SimplifyExpressionBodiedMember/SimplifyExpressionBodiedMemberAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SimplifyExpressionBodiedMember/SimplifyExpressionBodiedMemberAnalyzer.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.SimplifyExpressionBodiedMember
 {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SimplifyExpressionBodiedMember/SimplifyExpressionBodiedMemberAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SimplifyExpressionBodiedMember/SimplifyExpressionBodiedMemberAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.SimplifyExpressionBodiedMember
 {
@@ -62,28 +63,53 @@ namespace VSDiagnostics.Diagnostics.General.SimplifyExpressionBodiedMember
                 return null;
             }
 
-            if (
-                propertyDeclaration.DescendantNodesAndTokensAndSelf()
-                                   .Any(x => x.GetLeadingTrivia().Concat(x.GetTrailingTrivia()).Any(y => !y.IsWhitespaceTrivia())))
+            foreach (var declaration in propertyDeclaration.DescendantNodesAndTokensAndSelf())
             {
-                return null;
+                foreach (var trivia in declaration.GetLeadingTrivia())
+                {
+                    if (!trivia.IsWhitespaceTrivia())
+                    {
+                        return null;
+                    }
+                }
+
+                foreach (var trivia in declaration.GetTrailingTrivia())
+                {
+                    if (!trivia.IsWhitespaceTrivia())
+                    {
+                        return null;
+                    }
+                }
             }
 
-            if (propertyDeclaration.AccessorList.Accessors.Any(x => x.Keyword.IsKind(SyntaxKind.SetKeyword)))
+            foreach (var accessor in propertyDeclaration.AccessorList.Accessors)
             {
-                return null;
+                if (accessor.Keyword.IsKind(SyntaxKind.SetKeyword))
+                {
+                    return null;
+                }
             }
 
-            var getter =
-                propertyDeclaration.AccessorList.Accessors.FirstOrDefault(x => x.Keyword.IsKind(SyntaxKind.GetKeyword));
+            AccessorDeclarationSyntax getter = null;
+            foreach (var accessor in propertyDeclaration.AccessorList.Accessors)
+            {
+                if (accessor.Keyword.IsKind(SyntaxKind.GetKeyword))
+                {
+                    getter = accessor;
+                    break;
+                }
+            }
             if (getter == null)
             {
                 return null;
             }
 
-            if (getter.AttributeLists.Any(x => x.Attributes.Any()))
+            foreach (var list in getter.AttributeLists)
             {
-                return null;
+                if (list.Attributes.Any())
+                {
+                    return null;
+                }
             }
 
             if (getter.Body?.Statements.Count != 1)
@@ -107,11 +133,12 @@ namespace VSDiagnostics.Diagnostics.General.SimplifyExpressionBodiedMember
                 return null;
             }
 
-            if (
-                methodDeclaration.DescendantNodesAndTokensAndSelf()
-                                 .Any(x => x.GetLeadingTrivia().Concat(x.GetTrailingTrivia()).Any(y => !y.IsWhitespaceTrivia())))
+            foreach (var nodeOrToken in methodDeclaration.DescendantNodesAndTokensAndSelf())
             {
-                return null;
+                if (nodeOrToken.GetLeadingTrivia().Concat(nodeOrToken.GetTrailingTrivia()).Any(y => !y.IsWhitespaceTrivia()))
+                {
+                    return null;
+                }
             }
 
             if (methodDeclaration.Body?.Statements.Count != 1)

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SingleEmptyConstructor/SingleEmptyConstructorAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SingleEmptyConstructor/SingleEmptyConstructorAnalyzer.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.SingleEmptyConstructor
 {
@@ -56,7 +55,7 @@ namespace VSDiagnostics.Diagnostics.General.SingleEmptyConstructor
             }
 
             // ctor must not have attributes
-            if (constructorDeclaration.AttributeLists.NonLinqAny())
+            if (constructorDeclaration.AttributeLists.Any())
             {
                 return;
             }
@@ -85,7 +84,7 @@ namespace VSDiagnostics.Diagnostics.General.SingleEmptyConstructor
                     // we must return false (to avoid the parent if) only if it is the base keyword
                     // and there are no arguments.
                     if (!constructorInitializer.ThisOrBaseKeyword.IsKind(SyntaxKind.BaseKeyword) ||
-                        constructorInitializer.ArgumentList.Arguments.NonLinqAny())
+                        constructorInitializer.ArgumentList.Arguments.Any())
                     {
                         return;
                     }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SwitchDoesNotHandleAllEnumOptions/SwitchDoesNotHandleAllEnumOptionsAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SwitchDoesNotHandleAllEnumOptions/SwitchDoesNotHandleAllEnumOptionsAnalyzer.cs
@@ -5,8 +5,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
-// ReSharper disable LoopCanBePartlyConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.SwitchDoesNotHandleAllEnumOptions
 {
@@ -81,8 +79,8 @@ namespace VSDiagnostics.Diagnostics.General.SwitchDoesNotHandleAllEnumOptions
                 }
 
                 if (!switchHasSymbol)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, switchBlock.GetLocation()));
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, switchBlock.GetLocation()));
                     return;
                 }
             }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SwitchDoesNotHandleAllEnumOptions/SwitchDoesNotHandleAllEnumOptionsAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/SwitchDoesNotHandleAllEnumOptions/SwitchDoesNotHandleAllEnumOptionsAnalyzer.cs
@@ -5,8 +5,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
-// ReSharper disable LoopCanBePartlyConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.SwitchDoesNotHandleAllEnumOptions
 {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TryCastWithoutUsingAsNotNull/TryCastWithoutUsingAsNotNullAnalyzer.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
 {
@@ -42,7 +42,7 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                 return;
             }
 
-            var ifStatement = isExpression.AncestorsAndSelf().NonLinqOfType<IfStatementSyntax>(SyntaxKind.IfStatement).NonLinqFirstOrDefault();
+            var ifStatement = isExpression.AncestorsAndSelf().SyntaxNodeOfType<IfStatementSyntax>(SyntaxKind.IfStatement).FirstOrDefault();
             if (ifStatement == null)
             {
                 return;
@@ -69,8 +69,8 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
             }
 
             var castExpressions = new List<CastExpressionSyntax>();
-            castExpressions.AddRange(ifStatement.Statement.DescendantNodes().NonLinqOfType<CastExpressionSyntax>(SyntaxKind.CastExpression));
-            castExpressions.AddRange(ifStatement.Condition.DescendantNodesAndSelf().NonLinqOfType<CastExpressionSyntax>(SyntaxKind.CastExpression));
+            castExpressions.AddRange(ifStatement.Statement.DescendantNodes().SyntaxNodeOfType<CastExpressionSyntax>(SyntaxKind.CastExpression));
+            castExpressions.AddRange(ifStatement.Condition.DescendantNodesAndSelf().SyntaxNodeOfType<CastExpressionSyntax>(SyntaxKind.CastExpression));
 
             Action reportDiagnostic = () => context.ReportDiagnostic(Diagnostic.Create(Rule, isExpression.GetLocation(), isIdentifier));
 
@@ -88,7 +88,7 @@ namespace VSDiagnostics.Diagnostics.General.TryCastWithoutUsingAsNotNull
                     if (castedType.Type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
                     {
                         var nullableType = castedType.Type as INamedTypeSymbol;
-                        var argument = nullableType?.TypeArguments.NonLinqFirstOrDefault();
+                        var argument = nullableType?.TypeArguments.FirstOrDefault();
                         if (argument == null)
                         {
                             return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TypeToVar/TypeToVarAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/TypeToVar/TypeToVarAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -39,7 +38,7 @@ namespace VSDiagnostics.Diagnostics.General.TypeToVar
                 return;
             }
 
-            if (localDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.ConstKeyword)))
+            if (localDeclaration.Modifiers.NonLinqContains(SyntaxKind.ConstKeyword))
             {
                 return;
             }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -29,7 +28,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
 
             // A nameof() expression cannot contain aliases
             // There is no way to distinguish between a self-defined method 'nameof' and the nameof operator so we have to ignore all invocations that call into 'nameof'
-            var surroundingInvocation = identifier.Ancestors().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+            var surroundingInvocation = identifier.Ancestors().NonLinqOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression).NonLinqFirstOrDefault();
             if (surroundingInvocation != null && surroundingInvocation.IsNameofInvocation())
             {
                 return;
@@ -48,7 +47,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
             // We don't need it in this step but we have to point the analyzer to the right location
             // This will make sure that we accept the entire qualified name in the code fix
             var location = identifier.GetLocation();
-            var qualifiedName = identifier.AncestorsAndSelf().OfType<QualifiedNameSyntax>().FirstOrDefault();
+            var qualifiedName = identifier.AncestorsAndSelf().NonLinqOfType<QualifiedNameSyntax>(SyntaxKind.QualifiedName).NonLinqFirstOrDefault();
             if (qualifiedName?.Parent is UsingDirectiveSyntax)
             {
                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
@@ -28,7 +28,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
 
             // A nameof() expression cannot contain aliases
             // There is no way to distinguish between a self-defined method 'nameof' and the nameof operator so we have to ignore all invocations that call into 'nameof'
-            var surroundingInvocation = identifier.Ancestors().NonLinqOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression).NonLinqFirstOrDefault();
+            var surroundingInvocation = identifier.Ancestors().SyntaxNodeOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression).NonLinqFirstOrDefault();
             if (surroundingInvocation != null && surroundingInvocation.IsNameofInvocation())
             {
                 return;
@@ -47,7 +47,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
             // We don't need it in this step but we have to point the analyzer to the right location
             // This will make sure that we accept the entire qualified name in the code fix
             var location = identifier.GetLocation();
-            var qualifiedName = identifier.AncestorsAndSelf().NonLinqOfType<QualifiedNameSyntax>(SyntaxKind.QualifiedName).NonLinqFirstOrDefault();
+            var qualifiedName = identifier.AncestorsAndSelf().SyntaxNodeOfType<QualifiedNameSyntax>(SyntaxKind.QualifiedName).NonLinqFirstOrDefault();
             if (qualifiedName?.Parent is UsingDirectiveSyntax)
             {
                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/UseAliasesInsteadOfConcreteType/UseAliasesInsteadOfConcreteTypeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
 
             // A nameof() expression cannot contain aliases
             // There is no way to distinguish between a self-defined method 'nameof' and the nameof operator so we have to ignore all invocations that call into 'nameof'
-            var surroundingInvocation = identifier.Ancestors().SyntaxNodeOfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression).FirstOrDefault();
+            var surroundingInvocation = identifier.Ancestors().OfType<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression).FirstOrDefault();
             if (surroundingInvocation != null && surroundingInvocation.IsNameofInvocation())
             {
                 return;
@@ -48,7 +48,7 @@ namespace VSDiagnostics.Diagnostics.General.UseAliasesInsteadOfConcreteType
             // We don't need it in this step but we have to point the analyzer to the right location
             // This will make sure that we accept the entire qualified name in the code fix
             var location = identifier.GetLocation();
-            var qualifiedName = identifier.AncestorsAndSelf().SyntaxNodeOfType<QualifiedNameSyntax>(SyntaxKind.QualifiedName).FirstOrDefault();
+            var qualifiedName = identifier.AncestorsAndSelf().OfType<QualifiedNameSyntax>(SyntaxKind.QualifiedName).FirstOrDefault();
             if (qualifiedName?.Parent is UsingDirectiveSyntax)
             {
                 return;

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Strings/ReplaceEmptyStringWithStringDotEmpty/ReplaceEmptyStringWithStringDotEmptyAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Strings/ReplaceEmptyStringWithStringDotEmpty/ReplaceEmptyStringWithStringDotEmptyAnalyzer.cs
@@ -29,7 +29,7 @@ namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node.AncestorsAndSelf().SyntaxNodeOfType<AttributeArgumentSyntax>(SyntaxKind.AttributeArgument).Any())
+            if (context.Node.AncestorsAndSelf().OfType<AttributeArgumentSyntax>(SyntaxKind.AttributeArgument).Any())
             {
                 return;
             }
@@ -49,7 +49,7 @@ namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
                 }
             }
 
-            var variableDeclaration = stringLiteral.Ancestors().SyntaxNodeOfType<FieldDeclarationSyntax>(SyntaxKind.FieldDeclaration).FirstOrDefault();
+            var variableDeclaration = stringLiteral.Ancestors().OfType<FieldDeclarationSyntax>(SyntaxKind.FieldDeclaration).FirstOrDefault();
             if (variableDeclaration != null)
             {
                 foreach (var modifier in variableDeclaration.Modifiers)

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Strings/ReplaceEmptyStringWithStringDotEmpty/ReplaceEmptyStringWithStringDotEmptyAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Strings/ReplaceEmptyStringWithStringDotEmpty/ReplaceEmptyStringWithStringDotEmptyAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
 {
@@ -29,7 +29,7 @@ namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node.AncestorsAndSelf().NonLinqOfType<AttributeArgumentSyntax>(SyntaxKind.AttributeArgument).NonLinqAny())
+            if (context.Node.AncestorsAndSelf().SyntaxNodeOfType<AttributeArgumentSyntax>(SyntaxKind.AttributeArgument).Any())
             {
                 return;
             }
@@ -49,7 +49,7 @@ namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
                 }
             }
 
-            var variableDeclaration = stringLiteral.Ancestors().NonLinqOfType<FieldDeclarationSyntax>(SyntaxKind.FieldDeclaration).NonLinqFirstOrDefault();
+            var variableDeclaration = stringLiteral.Ancestors().SyntaxNodeOfType<FieldDeclarationSyntax>(SyntaxKind.FieldDeclaration).FirstOrDefault();
             if (variableDeclaration != null)
             {
                 foreach (var modifier in variableDeclaration.Modifiers)
@@ -67,16 +67,10 @@ namespace VSDiagnostics.Diagnostics.Strings.ReplaceEmptyStringWithStringDotEmpty
             //     case "": break;
             // }
             // Cannot be changed since it has to be a constant
-            foreach (var label in stringLiteral.AncestorsAndSelf())
+            if (stringLiteral.AncestorsAndSelf().OfType<SwitchLabelSyntax>().Any())
             {
-                if (label is SwitchLabelSyntax)
-                {
-                    return;
-                }
-            }
-            /*{
                 return;
-            }*/
+            }
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, stringLiteral.GetLocation()));
         }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Tests.RemoveTestSuffix
 {
@@ -52,7 +52,19 @@ namespace VSDiagnostics.Diagnostics.Tests.RemoveTestSuffix
                 return false;
             }
 
-            return attributes.Value.Any(x => methodAttributes.Contains(x.Name.ToString()));
+            foreach (var attribute in attributes.Value)
+            {
+                var attributeName = attribute.Name.ToString();
+                foreach (var methodAttribute in methodAttributes)
+                {
+                    if (Equals(methodAttribute, attributeName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Tests.RemoveTestSuffix
 {
@@ -55,12 +55,9 @@ namespace VSDiagnostics.Diagnostics.Tests.RemoveTestSuffix
             foreach (var attribute in attributes.Value)
             {
                 var attributeName = attribute.Name.ToString();
-                foreach (var methodAttribute in methodAttributes)
+                if (methodAttributes.Contains(attributeName))
                 {
-                    if (Equals(methodAttribute, attributeName))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutPublicModifier
 {
@@ -45,7 +45,20 @@ namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutPublicModifier
                 return false;
             }
 
-            return attributes.Value.Any(x => methodAttributes.Contains(x.Name.ToString()));
+            foreach (var attribute in attributes.Value)
+            {
+                var attributeName = attribute.Name.ToString();
+
+                foreach (var methodAttribute in methodAttributes)
+                {
+                    if (Equals(methodAttribute, attributeName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using VSDiagnostics.Utilities;
-// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutPublicModifier
 {
@@ -49,12 +49,9 @@ namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutPublicModifier
             {
                 var attributeName = attribute.Name.ToString();
 
-                foreach (var methodAttribute in methodAttributes)
+                if (methodAttributes.Contains(attributeName))
                 {
-                    if (Equals(methodAttribute, attributeName))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -244,7 +244,7 @@ namespace VSDiagnostics.Utilities
             return false;
         }
 
-        public static bool NonLinqAny(this List<SyntaxNode> list) => list.Count != 0;
+        public static bool NonLinqAny<T>(this List<T> list) where T : SyntaxNode => list.Count != 0;
 
         public static T NonLinqFirstOrDefault<T>(this IEnumerable<T> enumerable) where T : SyntaxNode
         {
@@ -253,9 +253,9 @@ namespace VSDiagnostics.Utilities
                 return node;
             }
 
-            throw new InvalidOperationException($"No elements exist in {nameof(enumerable)}");
+            return null;
         }
 
-        public static T NonLinqFirstOrDefault<T>(this List<T> list) where T : SyntaxNode => list[0];
+        public static T NonLinqFirstOrDefault<T>(this List<T> list) where T : SyntaxNode => list.NonLinqAny() ? list[0] : null;
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -244,18 +244,18 @@ namespace VSDiagnostics.Utilities
             return false;
         }
 
-        public static bool NonLinqAny<T>(this List<T> list) where T : SyntaxNode => list.Count != 0;
+        public static bool NonLinqAny<T>(this List<T> list) => list.Count != 0;
 
-        public static T NonLinqFirstOrDefault<T>(this IEnumerable<T> enumerable) where T : SyntaxNode
+        public static T NonLinqFirstOrDefault<T>(this IEnumerable<T> enumerable)
         {
             foreach (var node in enumerable)
             {
                 return node;
             }
 
-            return null;
+            return default(T);
         }
 
-        public static T NonLinqFirstOrDefault<T>(this List<T> list) where T : SyntaxNode => list.NonLinqAny() ? list[0] : null;
+        public static T NonLinqFirstOrDefault<T>(this List<T> list) => list.NonLinqAny() ? list[0] : default(T);
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -257,5 +257,34 @@ namespace VSDiagnostics.Utilities
         }
 
         public static T NonLinqFirstOrDefault<T>(this List<T> list) => list.NonLinqAny() ? list[0] : default(T);
+
+        public static bool NonLinqContainsAny(this SyntaxTokenList list, SyntaxKind[] kinds)
+        {
+            foreach (var item in list)
+            {
+                foreach (var kind in kinds)
+                {
+                    if (item.Kind() == kind)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool NonLinqContains(this SyntaxTokenList list, SyntaxKind kind)
+        {
+            foreach (var item in list)
+            {
+                if (item.Kind() == kind)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -219,7 +219,7 @@ namespace VSDiagnostics.Utilities
             return identifier != null && identifier.Identifier.ValueText == "nameof";
         }
 
-        public static List<T> OfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
+        public static List<T> NonLinqOfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
         {
             var list = new List<T>();
 
@@ -234,7 +234,7 @@ namespace VSDiagnostics.Utilities
             return list;
         }
 
-        public static bool Any(this IEnumerable<SyntaxNode> enumerable)
+        public static bool NonLinqAny(this IEnumerable<SyntaxNode> enumerable)
         {
             foreach (var node in enumerable)
             {
@@ -244,6 +244,18 @@ namespace VSDiagnostics.Utilities
             return false;
         }
 
-        public static bool Any(this List<SyntaxNode> list) => list.Count != 0;
+        public static bool NonLinqAny(this List<SyntaxNode> list) => list.Count != 0;
+
+        public static T NonLinqFirstOrDefault<T>(this IEnumerable<T> enumerable) where T : SyntaxNode
+        {
+            foreach (var node in enumerable)
+            {
+                return node;
+            }
+
+            throw new InvalidOperationException($"No elements exist in {nameof(enumerable)}");
+        }
+
+        public static T NonLinqFirstOrDefault<T>(this List<T> list) where T : SyntaxNode => list[0];
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -207,7 +207,7 @@ namespace VSDiagnostics.Utilities
             return identifier != null && identifier.Identifier.ValueText == "nameof";
         }
 
-        public static List<T> SyntaxNodeOfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
+        public static List<T> OfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
         {
             var list = new List<T>();
 
@@ -222,7 +222,7 @@ namespace VSDiagnostics.Utilities
             return list;
         }
 
-        public static bool ContainsAny(this SyntaxTokenList list, SyntaxKind[] kinds)
+        public static bool ContainsAny(this SyntaxTokenList list, params SyntaxKind[] kinds)
         {
             foreach (var item in list)
             {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+// ReSharper disable LoopCanBeConvertedToQuery
 
 namespace VSDiagnostics.Utilities
 {
@@ -217,5 +218,32 @@ namespace VSDiagnostics.Utilities
 
             return identifier != null && identifier.Identifier.ValueText == "nameof";
         }
+
+        public static List<T> OfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
+        {
+            var list = new List<T>();
+
+            foreach (var node in enumerable)
+            {
+                if (node.IsKind(kind))
+                {
+                    list.Add((T)node);
+                }
+            }
+
+            return list;
+        }
+
+        public static bool Any(this IEnumerable<SyntaxNode> enumerable)
+        {
+            foreach (var node in enumerable)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool Any(this List<SyntaxNode> list) => list.Count != 0;
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -286,5 +286,18 @@ namespace VSDiagnostics.Utilities
 
             return false;
         }
+
+        public static bool NonLinqContains(this IEnumerable<SyntaxKind> list, SyntaxKind kind)
+        {
+            foreach (var syntaxKind in list)
+            {
+                if (syntaxKind == kind)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-// ReSharper disable LoopCanBeConvertedToQuery
+
 
 namespace VSDiagnostics.Utilities
 {
@@ -219,7 +219,7 @@ namespace VSDiagnostics.Utilities
             return identifier != null && identifier.Identifier.ValueText == "nameof";
         }
 
-        public static List<T> NonLinqOfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
+        public static List<T> SyntaxNodeOfType<T>(this IEnumerable<SyntaxNode> enumerable, SyntaxKind kind) where T : SyntaxNode
         {
             var list = new List<T>();
 
@@ -234,31 +234,7 @@ namespace VSDiagnostics.Utilities
             return list;
         }
 
-        public static bool NonLinqAny(this IEnumerable<SyntaxNode> enumerable)
-        {
-            foreach (var node in enumerable)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public static bool NonLinqAny<T>(this List<T> list) => list.Count != 0;
-
-        public static T NonLinqFirstOrDefault<T>(this IEnumerable<T> enumerable)
-        {
-            foreach (var node in enumerable)
-            {
-                return node;
-            }
-
-            return default(T);
-        }
-
-        public static T NonLinqFirstOrDefault<T>(this List<T> list) => list.NonLinqAny() ? list[0] : default(T);
-
-        public static bool NonLinqContainsAny(this SyntaxTokenList list, SyntaxKind[] kinds)
+        public static bool ContainsAny(this SyntaxTokenList list, SyntaxKind[] kinds)
         {
             foreach (var item in list)
             {
@@ -274,7 +250,7 @@ namespace VSDiagnostics.Utilities
             return false;
         }
 
-        public static bool NonLinqContains(this SyntaxTokenList list, SyntaxKind kind)
+        public static bool Contains(this SyntaxTokenList list, SyntaxKind kind)
         {
             foreach (var item in list)
             {
@@ -287,7 +263,7 @@ namespace VSDiagnostics.Utilities
             return false;
         }
 
-        public static bool NonLinqContains(this IEnumerable<SyntaxKind> list, SyntaxKind kind)
+        public static bool Contains(this IEnumerable<SyntaxKind> list, SyntaxKind kind)
         {
             foreach (var syntaxKind in list)
             {
@@ -299,8 +275,5 @@ namespace VSDiagnostics.Utilities
 
             return false;
         }
-
-        public static T NonLinqLastOrDefault<T>(this IEnumerable<T> enumerable) => new List<T>(enumerable).NonLinqLastOrDefault();
-        public static T NonLinqLastOrDefault<T>(this List<T> list) => list.NonLinqAny() ? list[list.Count - 1] : default(T);
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -299,5 +299,8 @@ namespace VSDiagnostics.Utilities
 
             return false;
         }
+
+        public static T NonLinqLastOrDefault<T>(this IEnumerable<T> enumerable) => new List<T>(enumerable).NonLinqLastOrDefault();
+        public static T NonLinqLastOrDefault<T>(this List<T> list) => list.NonLinqAny() ? list[list.Count - 1] : default(T);
     }
 }


### PR DESCRIPTION
I did not remove it from the extensions or handlers (yet).  I didn't keep any `Contains` or `Any` calls that use lambdas, and I didn't keep any `Select`, `Where`, or `All` calls.  I also created a couple handy extensions methods to help with some calls, such as a `ContainsAny` that checks whether the items in a list contain any of the items in another list and a `Contains` to check whether a list of `SyntaxNode`s contain any of a given kind.

Closes #493